### PR TITLE
Feature/improve chain data fetch

### DIFF
--- a/apps/auxo-app/.husky/pre-commit
+++ b/apps/auxo-app/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+cd ./apps/auxo-app && yarn lint-staged 

--- a/apps/auxo-app/.lintstagedrc
+++ b/apps/auxo-app/.lintstagedrc
@@ -1,0 +1,3 @@
+{
+  "*.{ts,tsx,js,jsx}": ["eslint", "prettier --write"]
+} 

--- a/apps/auxo-app/package.json
+++ b/apps/auxo-app/package.json
@@ -58,6 +58,8 @@
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-prettier": "^3.1.4",
     "hardhat": "^2.8.2",
+    "husky": "^7.0.4",
+    "lint-staged": "^12.3.4",
     "typechain": "^6.1.0"
   },
   "scripts": {
@@ -68,7 +70,15 @@
     "eject": "react-scripts eject",
     "typechain": "typechain --target=ethers-v5 'src/abi/*.json' --out-dir src/types/artifacts/abi",
     "lint": "yarn format && npx eslint --fix src/*.{ts,tsx} src/**/*.{ts,tsx}",
-    "format": "npx prettier --write src/*.{ts,tsx} --write src/**/*.{ts,tsx}"
+    "format": "npx prettier --write src/*.{ts,tsx} --write src/**/*.{ts,tsx}",
+    "prepare": "cd ../../ && husky install ./apps/auxo-app/.husky"
+  },
+  "lint-staged": {
+    "*.@(ts|tsx)": [
+      "bash -c tsc -p .",
+      "yarn lint --max-warnings 0",
+      "yarn format"
+    ]
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/apps/auxo-app/src/App.tsx
+++ b/apps/auxo-app/src/App.tsx
@@ -6,25 +6,10 @@ import { Routes, Route } from "react-router-dom";
 import VaultDetails from "./pages/Vault";
 import AlertMessage from "./components/Header/AlertMessage";
 import Home from "./pages/Home";
-import { useEffect } from "react";
-import { useWeb3React } from "@web3-react/core";
-import { useAppDispatch } from "./hooks";
-import { setResetUserVaultDetails } from "./store/vault/vault.slice";
-
-const ChainDataComponent = () => {
-  useSetWeb3Cache();
-  const { account } = useWeb3React();
-  const { loading } = useChainData();
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    // Reset user-level stats if the account changes
-    dispatch(setResetUserVaultDetails());
-  }, [account, dispatch]);
-  return <div>{loading}</div>;
-};
 
 function App() {
+  useSetWeb3Cache();
+  useChainData();
   return (
     <div className="App text-center min-h-screen w-screen flex justify-center bg-gray-50">
       <section className=" max-w-[1440px] w-screen h-full min-h-screen justify-between flex flex-col items-center">
@@ -32,7 +17,6 @@ function App() {
           <Header />
           <section className="h-full w-full relative">
             <AlertMessage />
-            <ChainDataComponent />
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/vault/:vaultId" element={<VaultDetails />} />

--- a/apps/auxo-app/src/components/Header/AlertMessage.tsx
+++ b/apps/auxo-app/src/components/Header/AlertMessage.tsx
@@ -53,13 +53,11 @@ function AlertMessage(): JSX.Element {
   const alert = useAppSelector((state) => state.app.alert);
   const dispatch = useAppDispatch();
   useEffect(() => {
-    const timeout = setTimeout(
-      () => {
-        dispatch(setAlertDisplay(false));
-        // nicer to have pending alerts hang around a bit longer
-      },
-      alert.type === "PENDING" ? 6000 : 4000
-    );
+    // pending TX should show for duration
+    if (alert.type === "PENDING") return;
+    const timeout = setTimeout(() => {
+      dispatch(setAlertDisplay(false));
+    }, 4000);
     return () => {
       clearTimeout(timeout);
     };

--- a/apps/auxo-app/src/components/Header/AlertMessage.tsx
+++ b/apps/auxo-app/src/components/Header/AlertMessage.tsx
@@ -1,90 +1,103 @@
-import { useAppDispatch, useAppSelector } from "../../hooks"
-import { AlertTypes, AppState, setAlertDisplay } from "../../store/app/app.slice";
-import { RiCloseCircleFill } from 'react-icons/ri';
+import { useAppDispatch, useAppSelector } from "../../hooks";
+import {
+  AlertTypes,
+  AppState,
+  setAlertDisplay,
+} from "../../store/app/app.slice";
+import { RiCloseCircleFill } from "react-icons/ri";
 import LoadingSpinner from "../UI/loadingSpinner";
 import { changeNetwork, supportedChainIds } from "../../utils/networks";
 import { useEffect } from "react";
 
 const alertColor = (type: AlertTypes) => {
   switch (type) {
-    case 'SUCCESS': {
-      return 'bg-alert-success';
+    case "SUCCESS": {
+      return "bg-alert-success";
     }
-    case 'PENDING': {
-      return 'bg-alert-pending';
+    case "PENDING": {
+      return "bg-alert-pending";
     }
-    case 'ERROR': {
-      return 'bg-alert-error';
+    case "ERROR": {
+      return "bg-alert-error";
     }
     default: {
-      return 'bg-alert-error';
+      return "bg-alert-error";
     }
   }
-}
+};
 
 function SwitchNetworkButton() {
   const firstSupportedChainId = supportedChainIds[0];
   return (
-  <button 
-    className="mx-4 text-white border-2 border-red-300 rounded-lg px-3 hover:bg-red-300 hover:text-alert-error"
-    onClick={() => changeNetwork({ chainId: firstSupportedChainId })}>
-    Switch Network
-  </button>
-  )
+    <button
+      className="mx-4 text-white border-2 border-red-300 rounded-lg px-3 hover:bg-red-300 hover:text-alert-error"
+      onClick={() => changeNetwork({ chainId: firstSupportedChainId })}
+    >
+      Switch Network
+    </button>
+  );
 }
 
-function ActionButton({ alert }: { alert: AppState['alert'] }) {
+function ActionButton({ alert }: { alert: AppState["alert"] }) {
   switch (alert.action) {
-    case 'SWITCH_NETWORK': {
-      return <SwitchNetworkButton />
+    case "SWITCH_NETWORK": {
+      return <SwitchNetworkButton />;
     }
     default: {
-      return <></>
+      return <></>;
     }
   }
 }
 
 function AlertMessage(): JSX.Element {
-  const alert = useAppSelector(state => state.app.alert);
+  const alert = useAppSelector((state) => state.app.alert);
   const dispatch = useAppDispatch();
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      dispatch(setAlertDisplay(false));
-    }, 4_000);
+    const timeout = setTimeout(
+      () => {
+        dispatch(setAlertDisplay(false));
+        // nicer to have pending alerts hang around a bit longer
+      },
+      alert.type === "PENDING" ? 6000 : 4000
+    );
     return () => {
-      clearTimeout(timeout)
-    }
-  },[alert, dispatch])
+      clearTimeout(timeout);
+    };
+  }, [alert, dispatch]);
 
   return (
-      <div className={`
-        ${alert.show ? 'opacity-100 z-10' : 'opacity-0 -z-10' }
+    <div
+      className={`
+        ${alert.show ? "opacity-100 z-10" : "opacity-0 -z-10"}
           transition ease-in-out shadow-lg
           absolute flex justify-center w-full
-        `}>
-          <div className={`${alertColor(alert.type)} 
+        `}
+    >
+      <div
+        className={`${alertColor(alert.type)} 
           py-2 md:py-1 flex flex-wrap  
-          justify-center rounded-lg w-full items-center`
-        }>
+          justify-center rounded-lg w-full items-center`}
+      >
         <p className="text-white mr-2 m-1 sm:m-0">{alert.message}</p>
-        { 
-          alert.type === 'PENDING' && 
+        {alert.type === "PENDING" && (
           <span className="mx-2">
-            <LoadingSpinner spinnerClass="fill-white" className="text-white mx-2"/>
+            <LoadingSpinner
+              spinnerClass="fill-white"
+              className="text-white mx-2"
+            />
           </span>
-        }
-        { 
-          alert.action &&
-          <ActionButton alert={alert} />
-        }
+        )}
+        {alert.action && <ActionButton alert={alert} />}
         <button
           onClick={() => {
-            dispatch(setAlertDisplay(false))
-          }}><RiCloseCircleFill className="ml-2" color="white"/></button>
-        
+            dispatch(setAlertDisplay(false));
+          }}
+        >
+          <RiCloseCircleFill className="ml-2" color="white" />
+        </button>
       </div>
     </div>
-  )
+  );
 }
 
-export default AlertMessage
+export default AlertMessage;

--- a/apps/auxo-app/src/components/Vault/Actions/Deposit/DepositInput.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/Deposit/DepositInput.tsx
@@ -1,139 +1,156 @@
 import { useState } from "react";
 import { FaCheck } from "react-icons/fa";
 import { useMaxDeposit } from "../../../../hooks/useMaxDeposit";
-import { useApprovalLimit, useSelectedVault, useUserTokenBalance } from "../../../../hooks/useSelectedVault";
+import {
+  useApprovalLimit,
+  useSelectedVault,
+  useUserTokenBalance,
+} from "../../../../hooks/useSelectedVault";
 import { Balance } from "../../../../store/vault/Vault";
 import { compareBalances, zeroBalance } from "../../../../utils/balances";
 import StyledButton from "../../../UI/button";
 import InputSlider from "../InputSlider";
 import { useAppDispatch } from "../../../../hooks";
-import { useMonoVaultContract, useTokenContract } from "../../../../hooks/useContract";
+import {
+  useMonoVaultContract,
+  useTokenContract,
+} from "../../../../hooks/useContract";
 import LoadingSpinner from "../../../UI/loadingSpinner";
 import { useWeb3React } from "@web3-react/core";
 import { prettyNumber } from "../../../../utils";
 import { SetStateType } from "../../../../types/utilities";
 import { logoSwitcher } from "../../../../utils/logos";
-import { thunkApproveDeposit, thunkMakeDeposit } from "../../../../store/vault/vault.thunks";
+import {
+  thunkApproveDeposit,
+  thunkMakeDeposit,
+} from "../../../../store/vault/vault.thunks";
 
 function ApproveDepositButton({ deposit }: { deposit: Balance }) {
-    const [approving, setApproving] = useState(false);
-    const dispatch = useAppDispatch();
-    const vault = useSelectedVault();
-    const { limit } = useApprovalLimit();
-    const tokenContract = useTokenContract(vault?.token.address);
-    const { library } = useWeb3React();
+  const [approving, setApproving] = useState(false);
+  const dispatch = useAppDispatch();
+  const vault = useSelectedVault();
+  const { limit } = useApprovalLimit();
+  const tokenContract = useTokenContract(vault?.token.address);
 
-    const approveDeposit = () => {
-        setApproving(true);
-        dispatch(
-            thunkApproveDeposit({
-                deposit,
-                provider: library,
-                token: tokenContract
-            })
-        ).finally(() => setApproving(false));
-    }
+  const approveDeposit = () => {
+    setApproving(true);
+    dispatch(
+      thunkApproveDeposit({
+        deposit,
+        token: tokenContract,
+      })
+    ).finally(() => setApproving(false));
+  };
 
-    return (
-        <StyledButton
-            disabled={deposit.value === '0' || compareBalances(limit, 'gte', deposit)  || approving}
-            onClick={approveDeposit}
-        >
-            { approving
-                ? <LoadingSpinner />
-                : 'Approve'
-            }
-        </StyledButton>
-    )
+  return (
+    <StyledButton
+      disabled={
+        deposit.value === "0" ||
+        compareBalances(limit, "gte", deposit) ||
+        approving
+      }
+      onClick={approveDeposit}
+    >
+      {approving ? <LoadingSpinner /> : "Approve"}
+    </StyledButton>
+  );
 }
 
-function DepositButtons ({ deposit, setDeposit }: { deposit: Balance, setDeposit: SetStateType<Balance> }) {
-    const [depositing, setDepositing] = useState(false);
-    const dispatch = useAppDispatch();
-    const { account, library, chainId } = useWeb3React();
-    const { limit } = useApprovalLimit();
-    const vault = useSelectedVault();
-    const auxoContract = useMonoVaultContract(vault?.address);
+function DepositButtons({
+  deposit,
+  setDeposit,
+}: {
+  deposit: Balance;
+  setDeposit: SetStateType<Balance>;
+}) {
+  const [depositing, setDepositing] = useState(false);
+  const dispatch = useAppDispatch();
+  const { account, chainId } = useWeb3React();
+  const { limit } = useApprovalLimit();
+  const vault = useSelectedVault();
+  const auxoContract = useMonoVaultContract(vault?.address);
 
-    const buttonDisabled = () => {
-        const invalidDepost = deposit.label <= 0;
-        const sufficientApproval = compareBalances(limit, 'gte', deposit);
-        const wrongNetwork =  chainId !== vault?.network.chainId
-        return !sufficientApproval || wrongNetwork || invalidDepost || depositing; 
-    }   
+  const buttonDisabled = () => {
+    const invalidDepost = deposit.label <= 0;
+    const sufficientApproval = compareBalances(limit, "gte", deposit);
+    const wrongNetwork = chainId !== vault?.network.chainId;
+    return !sufficientApproval || wrongNetwork || invalidDepost || depositing;
+  };
 
-    const makeDeposit = () => { 
-        setDepositing(true);
-        dispatch(
-            thunkMakeDeposit({
-                account, 
-                auxo: auxoContract,
-                deposit,
-                provider: library
-            })
-        )
-        .then(() => setDeposit(zeroBalance()))
-        .finally(() => setDepositing(false));
-    }
-  
-    return (
-        <>
-        <div 
+  const makeDeposit = () => {
+    setDepositing(true);
+    dispatch(
+      thunkMakeDeposit({
+        account,
+        auxo: auxoContract,
+        deposit,
+      })
+    )
+      .then(() => setDeposit(zeroBalance()))
+      .finally(() => setDepositing(false));
+  };
+
+  return (
+    <>
+      <div
         className={`rounded-full p-2 
-            ${
-                !buttonDisabled()
-                ? 'bg-baby-blue-dark'
-                : 'bg-gray-300'
-            }`
-        }>
-        <FaCheck className='fill-white w-4 h-4'/>
-        </div>
-        <StyledButton
-            disabled={buttonDisabled()}
-            onClick={makeDeposit}
-            className={
-                !buttonDisabled()
-                ? 'bg-baby-blue-dark'
-                : 'bg-gray-300'
-            }
-        >
-            Deposit
-        </StyledButton>
-        </>
-    )
+            ${!buttonDisabled() ? "bg-baby-blue-dark" : "bg-gray-300"}`}
+      >
+        <FaCheck className="fill-white w-4 h-4" />
+      </div>
+      <StyledButton
+        disabled={buttonDisabled()}
+        onClick={makeDeposit}
+        className={!buttonDisabled() ? "bg-baby-blue-dark" : "bg-gray-300"}
+      >
+        Deposit
+      </StyledButton>
+    </>
+  );
 }
 
-function DepositActions({ deposit, setDeposit }: { deposit: Balance, setDeposit: SetStateType<Balance> }) {
-    return (
-        <div
-            className="flex justify-between items-center"
-        >
-            <ApproveDepositButton deposit={deposit} />
-            <DepositButtons deposit={deposit} setDeposit={setDeposit} />
-        </div>
-    )
+function DepositActions({
+  deposit,
+  setDeposit,
+}: {
+  deposit: Balance;
+  setDeposit: SetStateType<Balance>;
+}) {
+  return (
+    <div className="flex justify-between items-center">
+      <ApproveDepositButton deposit={deposit} />
+      <DepositButtons deposit={deposit} setDeposit={setDeposit} />
+    </div>
+  );
 }
 
 function DepositInput() {
-    const [deposit, setDeposit] = useState(zeroBalance());
-    const vault = useSelectedVault();
-    const max = useMaxDeposit();
-    const currency = useSelectedVault()?.symbol;
-    const balance = useUserTokenBalance();
-    const label = prettyNumber(balance.label) + ' ' + currency
+  const [deposit, setDeposit] = useState(zeroBalance());
+  const vault = useSelectedVault();
+  const max = useMaxDeposit();
+  const currency = useSelectedVault()?.symbol;
+  const balance = useUserTokenBalance();
+  const label = prettyNumber(balance.label) + " " + currency;
 
-    return (
-        <div className="sm:my-2 flex flex-col h-full w-full justify-evenly px-4">
-            <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
-                <div className="h-6 w-6 sm:h-8 sm:w-8 mr-3">{ logoSwitcher(vault?.symbol) }</div>
-                <p className="text-gray-700 md:text-xl">Deposit {currency}</p>
-            </div>
-            <div className="my-1">
-                <InputSlider value={deposit} setValue={setDeposit} max={max} label={label}/>
-            </div>
-            <DepositActions deposit={deposit} setDeposit={setDeposit}/>
+  return (
+    <div className="sm:my-2 flex flex-col h-full w-full justify-evenly px-4">
+      <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
+        <div className="h-6 w-6 sm:h-8 sm:w-8 mr-3">
+          {logoSwitcher(vault?.symbol)}
         </div>
-    )
+        <p className="text-gray-700 md:text-xl">Deposit {currency}</p>
+      </div>
+      <div className="my-1">
+        <InputSlider
+          value={deposit}
+          setValue={setDeposit}
+          max={max}
+          label={label}
+        />
+      </div>
+      <DepositActions deposit={deposit} setDeposit={setDeposit} />
+    </div>
+  );
 }
 
 export default DepositInput;

--- a/apps/auxo-app/src/components/Vault/Actions/MerkleAuthCheck.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/MerkleAuthCheck.tsx
@@ -2,7 +2,7 @@ import { useWeb3React } from "@web3-react/core";
 import { useState } from "react";
 import { FaCheckCircle } from "react-icons/fa";
 import { useAppDispatch } from "../../../hooks";
-import { useMerkleAuthContract } from "../../../hooks/useContract"
+import { useMerkleAuthContract } from "../../../hooks/useContract";
 import { Vault } from "../../../store/vault/Vault";
 import { thunkAuthorizeDepositor } from "../../../store/vault/vault.thunks";
 import { AUXO_HELP_URL } from "../../../utils";
@@ -11,67 +11,78 @@ import StyledButton from "../../UI/button";
 import LoadingSpinner from "../../UI/loadingSpinner";
 import ExternalUrl from "../../UI/url";
 
-const veDoughLogo = process.env.PUBLIC_URL + '/veDough-only.png'
+const veDoughLogo = process.env.PUBLIC_URL + "/veDough-only.png";
 
 const MerkleVerify = ({ vault }: { vault: Vault }): JSX.Element => {
-  const needsToVerifyString = 'You need to verify before you can use this vault'
-  const verifiedString = 'Account has been verfied';
-  const notAuthorizedString = 'This vault is restricted to veDOUGH holders only';
+  const needsToVerifyString =
+    "You need to verify before you can use this vault";
+  const verifiedString = "Account has been verfied";
+  const notAuthorizedString =
+    "This vault is restricted to veDOUGH holders only";
 
   const dispatch = useAppDispatch();
-  const { account, library, chainId } = useWeb3React();
+  const { account, chainId } = useWeb3React();
   const authContract = useMerkleAuthContract(vault.auth.address);
-  const isDepositor = vault.auth.isDepositor
+  const isDepositor = vault.auth.isDepositor;
   const [authorizing, setAuthorizing] = useState(false);
-  
+
   const proof = getProof(account);
   const isDisabled = (): boolean => {
     const wrongNetwork = chainId !== vault.network.chainId;
     return authorizing || wrongNetwork || !proof;
-  }
-    
+  };
 
   const submitProof = () => {
-    setAuthorizing(true)
+    setAuthorizing(true);
     dispatch(
       thunkAuthorizeDepositor({
-        account, 
+        account,
         auth: authContract,
-        provider: library
       })
     ).finally(() => setAuthorizing(false));
   };
 
   return (
-    <div className="p-5 flex flex-col items-center justify-center">{ 
-      false 
-      ? <LoadingSpinner className="text-gray-600" spinnerClass="text-red"/>
-      :
-      <>
-      { !isDepositor &&
-        <div className="m-auto w-1/2">
-          <img src={veDoughLogo} alt="veDough-holders-only"/>
-        </div>
-      }
-      <p className="my-3 text-lg text-gray-700">{isDepositor ? (proof ? verifiedString : needsToVerifyString) : notAuthorizedString}</p>
-      {
-        isDepositor && <FaCheckCircle size={28} className="fill-baby-blue-dark" />
-      }
-      { 
-        (!isDepositor && proof) && 
-        <StyledButton className="md:w-1/2" 
-          onClick={submitProof}
-          disabled={isDisabled()}>{ authorizing ? <LoadingSpinner /> :'Opt In' }</StyledButton>
-      }
-      { 
-        !isDepositor && 
-        <ExternalUrl to={AUXO_HELP_URL}>
-          <p className="underline text-baby-blue-dark underline-offset-2 text-semibold">More Info</p>
-        </ExternalUrl>
-      }
-      </>
-    }</div>
-  )
-}
+    <div className="p-5 flex flex-col items-center justify-center">
+      {false ? (
+        <LoadingSpinner className="text-gray-600" spinnerClass="text-red" />
+      ) : (
+        <>
+          {!isDepositor && (
+            <div className="m-auto w-1/2">
+              <img src={veDoughLogo} alt="veDough-holders-only" />
+            </div>
+          )}
+          <p className="my-3 text-lg text-gray-700">
+            {isDepositor
+              ? proof
+                ? verifiedString
+                : needsToVerifyString
+              : notAuthorizedString}
+          </p>
+          {isDepositor && (
+            <FaCheckCircle size={28} className="fill-baby-blue-dark" />
+          )}
+          {!isDepositor && proof && (
+            <StyledButton
+              className="md:w-1/2"
+              onClick={submitProof}
+              disabled={isDisabled()}
+            >
+              {authorizing ? <LoadingSpinner /> : "Opt In"}
+            </StyledButton>
+          )}
+          {!isDepositor && (
+            <ExternalUrl to={AUXO_HELP_URL}>
+              <p className="underline text-baby-blue-dark underline-offset-2 text-semibold">
+                More Info
+              </p>
+            </ExternalUrl>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
 
-export default MerkleVerify
+export default MerkleVerify;

--- a/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawButton.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawButton.tsx
@@ -1,4 +1,3 @@
-import { useWeb3React } from "@web3-react/core";
 import { useState } from "react";
 import { useAppDispatch } from "../../../../hooks";
 import { useWeb3Cache } from "../../../../hooks/useCachedWeb3";
@@ -11,50 +10,45 @@ import { prettyNumber } from "../../../../utils";
 import StyledButton from "../../../UI/button";
 import LoadingSpinner from "../../../UI/loadingSpinner";
 
-function WithdrawButton ({ showAvailable }: { showAvailable?: boolean }) {
-    const [withdrawing, setWithdrawing] = useState(false);
-    const { chainId } = useWeb3Cache();
-    const vault = useSelectedVault();
-    const dispatch = useAppDispatch();
-    const { library } = useWeb3React();
-    const auxoContract = useMonoVaultContract(vault?.address);
-    const available = vault?.userBalances?.batchBurn.available;
-    const status = useStatus();
-    const pendingSharesUnderlying = useApproximatePendingAsUnderlying();
+function WithdrawButton({ showAvailable }: { showAvailable?: boolean }) {
+  const [withdrawing, setWithdrawing] = useState(false);
+  const { chainId } = useWeb3Cache();
+  const vault = useSelectedVault();
+  const dispatch = useAppDispatch();
+  const auxoContract = useMonoVaultContract(vault?.address);
+  const available = vault?.userBalances?.batchBurn.available;
+  const status = useStatus();
+  const pendingSharesUnderlying = useApproximatePendingAsUnderlying();
 
-    const buttonText = showAvailable ? prettyNumber(available?.label) : 'WITHDRAW';
-    
-    const buttonDisabled = () => {
-        const wrongStatus = status !== WITHDRAWAL.READY
-        const wrongNetwork =  chainId !== vault?.network.chainId
-        return wrongNetwork || withdrawing || wrongStatus; 
-    }
+  const buttonText = showAvailable
+    ? prettyNumber(available?.label)
+    : "WITHDRAW";
 
-    const makeWithdrawal = () => {
-        setWithdrawing(true);
-        dispatch(
-            thunkConfirmWithdrawal({
-                auxo: auxoContract,
-                provider: library,
-                pendingSharesUnderlying
-            })
-        )
-        .finally(() => setWithdrawing(false))
-    };
+  const buttonDisabled = () => {
+    const wrongStatus = status !== WITHDRAWAL.READY;
+    const wrongNetwork = chainId !== vault?.network.chainId;
+    return wrongNetwork || withdrawing || wrongStatus;
+  };
 
-    return (
-        <StyledButton
-            disabled={buttonDisabled()}
-            onClick={makeWithdrawal}
-            className="min-w-[60px]"
-        >
-            { 
-                withdrawing
-                    ? <LoadingSpinner />
-                    : buttonText
-            } 
-        </StyledButton>
-    )
+  const makeWithdrawal = () => {
+    setWithdrawing(true);
+    dispatch(
+      thunkConfirmWithdrawal({
+        auxo: auxoContract,
+        pendingSharesUnderlying,
+      })
+    ).finally(() => setWithdrawing(false));
+  };
+
+  return (
+    <StyledButton
+      disabled={buttonDisabled()}
+      onClick={makeWithdrawal}
+      className="min-w-[60px]"
+    >
+      {withdrawing ? <LoadingSpinner /> : buttonText}
+    </StyledButton>
+  );
 }
 
-export default WithdrawButton
+export default WithdrawButton;

--- a/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawInput.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawInput.tsx
@@ -1,8 +1,10 @@
-import { useWeb3React } from "@web3-react/core";
 import { useState } from "react";
 import { useAppDispatch } from "../../../../hooks";
 import { useMonoVaultContract } from "../../../../hooks/useContract";
-import { useSelectedVault, useVaultTokenBalance } from "../../../../hooks/useSelectedVault";
+import {
+  useSelectedVault,
+  useVaultTokenBalance,
+} from "../../../../hooks/useSelectedVault";
 import { useStatus, WITHDRAWAL } from "../../../../hooks/useWithdrawalStatus";
 import { Balance } from "../../../../store/vault/Vault";
 import { thunkIncreaseWithdrawal } from "../../../../store/vault/vault.thunks";
@@ -16,94 +18,114 @@ import ExternalUrl from "../../../UI/url";
 import InputSlider from "../InputSlider";
 import WithdrawButton from "./WithdrawButton";
 
-function ApproveWithdrawButton({ withdraw, setWithdraw }: { withdraw: Balance, setWithdraw: SetStateType<Balance> }) {
-    const [approving, setApproving] = useState(false);
-    const dispatch = useAppDispatch();
-    const vault = useSelectedVault();
-    const auxoContract = useMonoVaultContract(vault?.address);
-    const status = useStatus();
-    const { library } = useWeb3React();
+function ApproveWithdrawButton({
+  withdraw,
+  setWithdraw,
+}: {
+  withdraw: Balance;
+  setWithdraw: SetStateType<Balance>;
+}) {
+  const [approving, setApproving] = useState(false);
+  const dispatch = useAppDispatch();
+  const vault = useSelectedVault();
+  const auxoContract = useMonoVaultContract(vault?.address);
+  const status = useStatus();
 
-    const enterBatchBurn = () => {
-        setApproving(true);
-        dispatch(
-            thunkIncreaseWithdrawal({
-                auxo: auxoContract,
-                provider: library,
-                withdraw
-            })
-        ).then(() => setWithdraw(zeroBalance()))
-        .finally(() => setApproving(false));
-    };
-
-    return (
-        <StyledButton
-            disabled={withdraw.value === '0' || status === WITHDRAWAL.READY || approving}
-            onClick={enterBatchBurn}
-        >
-            { approving
-                ? <LoadingSpinner />
-                : 'Request'
-            }
-        </StyledButton>
+  const enterBatchBurn = () => {
+    setApproving(true);
+    dispatch(
+      thunkIncreaseWithdrawal({
+        auxo: auxoContract,
+        withdraw,
+      })
     )
-};
+      .then(() => setWithdraw(zeroBalance()))
+      .finally(() => setApproving(false));
+  };
 
-function WithdrawActions({ withdraw, setWithdraw }: { withdraw: Balance, setWithdraw: SetStateType<Balance> }) {
-    return (
-        <div
-            className="flex w-full justify-start items-center"
-        >
-                <button className="w-full flex justify-start ml-1 text-sm text-gray-500">
-                    <ExternalUrl to={AUXO_HELP_URL + '#c49e2f5991784b7fbb9e7cfac16def3f'}>
-                        <p><span className="underline decoration-baby-blue-dark">More Info</span><span className="hidden sm:inline-block ml-1">on withdrawals</span></p>
-                    </ExternalUrl>
-                </button>
-                <ApproveWithdrawButton withdraw={withdraw} setWithdraw={setWithdraw}/>
-            </div>
-    )
+  return (
+    <StyledButton
+      disabled={
+        withdraw.value === "0" || status === WITHDRAWAL.READY || approving
+      }
+      onClick={enterBatchBurn}
+    >
+      {approving ? <LoadingSpinner /> : "Request"}
+    </StyledButton>
+  );
 }
 
+function WithdrawActions({
+  withdraw,
+  setWithdraw,
+}: {
+  withdraw: Balance;
+  setWithdraw: SetStateType<Balance>;
+}) {
+  return (
+    <div className="flex w-full justify-start items-center">
+      <button className="w-full flex justify-start ml-1 text-sm text-gray-500">
+        <ExternalUrl to={AUXO_HELP_URL + "#c49e2f5991784b7fbb9e7cfac16def3f"}>
+          <p>
+            <span className="underline decoration-baby-blue-dark">
+              More Info
+            </span>
+            <span className="hidden sm:inline-block ml-1">on withdrawals</span>
+          </p>
+        </ExternalUrl>
+      </button>
+      <ApproveWithdrawButton withdraw={withdraw} setWithdraw={setWithdraw} />
+    </div>
+  );
+}
 
 function WithdrawInput() {
-    const [withdraw, setWithdraw] = useState(zeroBalance());
-    const currency = useSelectedVault()?.symbol;
-    const vault = useSelectedVault();
-    const balance = useVaultTokenBalance();
-    const status = useStatus();
-    const label = status === WITHDRAWAL.READY
-        ? 'Ready to Withdraw'
-        : prettyNumber(balance.label) + ' auxo' + currency
-    return (
-        <div 
-            className="
+  const [withdraw, setWithdraw] = useState(zeroBalance());
+  const currency = useSelectedVault()?.symbol;
+  const vault = useSelectedVault();
+  const balance = useVaultTokenBalance();
+  const status = useStatus();
+  const label =
+    status === WITHDRAWAL.READY
+      ? "Ready to Withdraw"
+      : prettyNumber(balance.label) + " auxo" + currency;
+  return (
+    <div
+      className="
             sm:my-2 flex flex-col h-full w-full justify-evenly px-4
-        ">
-            <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
-                <div className="h-6 w-6 sm:h-8 sm:w-8">{ logoSwitcher(vault?.symbol) }</div>
-                <p className="text-gray-700 md:text-xl ml-3 mr-1">Convert auxo{currency} to {currency}</p>
-            </div>
-            {   (status === WITHDRAWAL.READY) ?
-                <div className="h-64 bg-baby-blue-light rounded-xl p-3 text-baby-blue-dark mt-3 flex flex-col items-center justify-evenly">
-                    <p className="text-4xl font-bold underline underline-offset-4 decoration-white">Ready to Withdraw</p>
-                    <p className="">Withdraw your existing balance</p>
-                    <WithdrawButton />
-                </div>
-                : 
-                <>
-                <div className="my-1">
-                    <InputSlider 
-                        value={withdraw}
-                        setValue={setWithdraw}
-                        max={balance}
-                        label={label}
-                    />
-                </div>
-                <WithdrawActions withdraw={withdraw} setWithdraw={setWithdraw} />
-                </>
-            }
+        "
+    >
+      <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
+        <div className="h-6 w-6 sm:h-8 sm:w-8">
+          {logoSwitcher(vault?.symbol)}
         </div>
-    )
+        <p className="text-gray-700 md:text-xl ml-3 mr-1">
+          Convert auxo{currency} to {currency}
+        </p>
+      </div>
+      {status === WITHDRAWAL.READY ? (
+        <div className="h-64 bg-baby-blue-light rounded-xl p-3 text-baby-blue-dark mt-3 flex flex-col items-center justify-evenly">
+          <p className="text-4xl font-bold underline underline-offset-4 decoration-white">
+            Ready to Withdraw
+          </p>
+          <p className="">Withdraw your existing balance</p>
+          <WithdrawButton />
+        </div>
+      ) : (
+        <>
+          <div className="my-1">
+            <InputSlider
+              value={withdraw}
+              setValue={setWithdraw}
+              max={balance}
+              label={label}
+            />
+          </div>
+          <WithdrawActions withdraw={withdraw} setWithdraw={setWithdraw} />
+        </>
+      )}
+    </div>
+  );
 }
 
 export default WithdrawInput;

--- a/apps/auxo-app/src/components/Vault/Details/StatusRows.tsx
+++ b/apps/auxo-app/src/components/Vault/Details/StatusRows.tsx
@@ -7,58 +7,62 @@ import { logoSwitcher } from "../../../utils/logos";
 import { getProof } from "../../../utils/merkleProof";
 
 export const VEDoughChecker = (): JSX.Element => {
-    const { account } = useWeb3React();
-    const hasVedough = getProof(account);
-    return (
-      <div className="bg-white rounded-md p-2 text-xs sm:text-sm lg:text-base">
-        {
-        hasVedough 
-          ? <div className="font-bold px-2 text-baby-blue-dark">Account is a veDOUGH holder</div>
-          : 
-            <div className="flex items-center mx-5 bg-white font-bold rounded-md ">
-              <IoWarningOutline className="text-return-100" />
-              <p className="ml-2 text-return-100">veDOUGH access only</p>
-            </div> 
-        }
-      </div>
-    )
-}
-  
-export const VEDoughStatusRow = () => {
-    const navigate = useNavigate();
-    return (
-        <div className="flex flex-wrap items-center justify-between mt-5 px-1 sm:px-0 sm:mt-0">
-          <div className="flex items-center text-baby-blue-dark">
-            <button onClick={() => {navigate('/')}} className="bg-white rounded-md shadow-sm sm:shadow-md p-2 sm:p-3">
-            <IoChevronBack />
-            </button>
-          </div>
-          <VEDoughChecker />
+  const { account } = useWeb3React();
+  const hasVedough = getProof(account);
+  return (
+    <div className="bg-white rounded-md p-2 text-xs sm:text-sm lg:text-base">
+      {hasVedough ? (
+        <div className="font-bold px-2 text-baby-blue-dark">
+          Account is a veDOUGH holder
         </div>
-    )
-}
-  
+      ) : (
+        <div className="flex items-center mx-5 bg-white font-bold rounded-md ">
+          <IoWarningOutline className="text-return-100" />
+          <p className="ml-2 text-return-100">veDOUGH access only</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const VEDoughStatusRow = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="flex flex-wrap items-center justify-between mt-5 px-1 sm:px-0 sm:mt-0">
+      <div className="flex items-center text-baby-blue-dark">
+        <button
+          onClick={() => {
+            navigate("/");
+          }}
+          className="bg-white rounded-md shadow-sm sm:shadow-md p-2 sm:p-3"
+        >
+          <IoChevronBack />
+        </button>
+      </div>
+      <VEDoughChecker />
+    </div>
+  );
+};
+
 export const FloatingBackground = (): JSX.Element => {
   return (
     <div className="relative pt-1 mt-5 z-0 w-full">
       <div className="bg-baby-blue-light rounded-xl h-48 w-full absolute top-0 -z-20" />
-      <div className="flex items-center justify-between w-full sm:justify-between m-3">
-      </div>
+      <div className="flex items-center justify-between w-full sm:justify-between m-3"></div>
     </div>
-  )
-}
+  );
+};
 
 export const VaultPoolAPY = ({ vault }: { vault: Vault | undefined }) => {
   let message = useApy(vault);
-  if (message !== 'New Vault') message = message + ' APY';
+  if (message !== "New Vault") message = message + " APY";
   return (
     <div className="hidden lg:flex h-6 justify-start mb-5 items-center z-20">
-      <div className="h-7 w-auto flex ml-3">
-        { logoSwitcher(vault?.symbol) }
-      </div>
-      <p className="ml-3 md:font-bold md:text-2xl text-gray-700"
-          >{vault?.symbol} pool <span className="font-extrabold text-return-100 mr-3">{message}</span>
+      <div className="h-7 w-7 flex ml-3">{logoSwitcher(vault?.symbol)}</div>
+      <p className="ml-3 md:font-bold md:text-2xl text-gray-700">
+        {vault?.symbol} pool{" "}
+        <span className="font-extrabold text-return-100 mr-3">{message}</span>
       </p>
     </div>
-  )
-}
+  );
+};

--- a/apps/auxo-app/src/components/Vault/Details/VaultCapSlider.tsx
+++ b/apps/auxo-app/src/components/Vault/Details/VaultCapSlider.tsx
@@ -1,48 +1,64 @@
-import { useSelectedVault } from "../../../hooks/useSelectedVault"
+import { useSelectedVault } from "../../../hooks/useSelectedVault";
 import { prettyNumber } from "../../../utils";
 import { zeroBalance } from "../../../utils/balances";
 import { useApproximatePendingAsUnderlying } from "../../../hooks/useMaxDeposit";
+import { FaLock } from "react-icons/fa";
 
 export const useLocked = (): number => {
-    /**
-     * When computing total value locked in auxo, we take the deposits in underlying USDC
-     * We also add the shares in the batch burn process, multiplied by the Exchange rate
-     * NB: need to understand how much ER and Amount Per Share can differ
-     */
-    const vault = useSelectedVault();
-    const amountDepositedUnderlying = vault?.userBalances?.vaultUnderlying ?? zeroBalance();
-    const amountPendingUnderlying = useApproximatePendingAsUnderlying();
-    return amountPendingUnderlying.label + amountDepositedUnderlying.label  
+  /**
+   * When computing total value locked in auxo, we take the deposits in underlying USDC
+   * We also add the shares in the batch burn process, multiplied by the Exchange rate
+   * NB: need to understand how much ER and Amount Per Share can differ
+   */
+  const vault = useSelectedVault();
+  const amountDepositedUnderlying =
+    vault?.userBalances?.vaultUnderlying ?? zeroBalance();
+  const amountPendingUnderlying = useApproximatePendingAsUnderlying();
+  return amountPendingUnderlying.label + amountDepositedUnderlying.label;
 };
 
 const VaultCapSlider = () => {
-    const vault = useSelectedVault()
-    const deposits = vault?.userBalances?.vaultUnderlying
-    const cap = vault?.cap.underlying;
-    const currency = vault?.symbol;
-    const amount = useLocked();
-    const barWidth = (): string => (cap ? Math.round(amount / cap.label * 100) : 0) + '%';
+  const vault = useSelectedVault();
+  const deposits = vault?.userBalances?.vaultUnderlying;
+  const cap = vault?.cap.underlying;
+  const currency = vault?.symbol;
+  const amount = useLocked();
+  const barWidth = (): string =>
+    (cap ? Math.round((amount / cap.label) * 100) : 0) + "%";
 
-    return (
-        <div className="flex flex-col w-full text-baby-blue-dark text-xs sm:text-sm font-bold mb-3 sm:mb-2 px-1 sm:px-0">
-            <div className="flex w-full justify-between px-1 mb-1 sm:mb-0">
-                    {
-                        deposits
-                        ? <p>{ prettyNumber(amount) } { currency }</p>
-                        : <p>0 {currency}</p>
-                    }
-                    <p><span className="hidden sm:inline-block">MAX:</span> { prettyNumber(cap?.label) } { currency }</p>
-            </div>
-            <div className="w-full px-1 rounded-xl h-2 sm:h-4 flex items-center bg-white">
-                <div className="h-1 sm:h-2 rounded-xl
+  return (
+    <div className="flex flex-col w-full text-baby-blue-dark text-xs sm:text-sm font-bold mb-3 sm:mb-2 px-1 sm:px-0">
+      <div className="flex w-full justify-between px-1 mb-1 sm:mb-0">
+        <div className="flex items-center">
+          <FaLock className="mr-1" />
+          {deposits ? (
+            <p>
+              {prettyNumber(amount)} {currency}
+            </p>
+          ) : (
+            <p>0 {currency}</p>
+          )}
+        </div>
+        <p>
+          <span className="hidden sm:inline-block">MAX:</span>{" "}
+          {prettyNumber(cap?.label)} {currency}
+        </p>
+      </div>
+      <div className="w-full px-1 rounded-xl h-2 sm:h-4 flex items-center bg-white">
+        <div
+          className="h-1 sm:h-2 rounded-xl
                     bg-gradient-to-r from-return-0 via-return-60 to-return-100
                    "
-                   // cannot use string concat with arbitrary tailwind values
-                   style={{ width: barWidth(), transitionDuration: '1s', transitionProperty: 'all' }}
-                   ></div>
-            </div>
-        </div>
-    )
-}
+          // cannot use string concat with arbitrary tailwind values
+          style={{
+            width: barWidth(),
+            transitionDuration: "1s",
+            transitionProperty: "all",
+          }}
+        ></div>
+      </div>
+    </div>
+  );
+};
 
-export default VaultCapSlider
+export default VaultCapSlider;

--- a/apps/auxo-app/src/components/Vault/Details/VaultSummaryUser.tsx
+++ b/apps/auxo-app/src/components/Vault/Details/VaultSummaryUser.tsx
@@ -1,57 +1,70 @@
-import { useApproximatePendingAsUnderlying } from "../../../hooks/useMaxDeposit"
-import { Vault } from "../../../store/vault/Vault"
-import { prettyNumber } from "../../../utils"
-import CardItem from "../../UI/cardItem"
-import WithdrawButton from "../Actions/Withdraw/WithdrawButton"
+import { useApproximatePendingAsUnderlying } from "../../../hooks/useMaxDeposit";
+import { Vault } from "../../../store/vault/Vault";
+import { prettyNumber } from "../../../utils";
+import CardItem from "../../UI/cardItem";
+import WithdrawButton from "../Actions/Withdraw/WithdrawButton";
+import { useLocked } from "./VaultCapSlider";
 
+const VaultSummaryUser = ({
+  loading,
+  vault,
+}: {
+  loading: boolean;
+  vault: Vault | undefined;
+}) => {
+  const pendingUnderlying = useApproximatePendingAsUnderlying();
+  const locked = useLocked();
+  return (
+    <section
+      className="
+        flex flex-col w-full justify-evenly h-full items-center"
+    >
+      <CardItem
+        loading={loading}
+        left={`Your auxo${vault?.symbol} Balance`}
+        right={prettyNumber(vault?.userBalances?.vault.label)}
+      />
+      <CardItem
+        loading={loading}
+        left={`Est. ${vault?.symbol} Value`}
+        right={prettyNumber(vault?.userBalances?.vaultUnderlying.label)}
+      />
+      <CardItem loading={loading} left="Fees" right="0 %" />
+      <div
+        className="
+          h-[1px] bg-gray-300 w-full my-5"
+      />
+      <CardItem
+        loading={loading}
+        left={`Your ${vault?.symbol} Wallet Balance`}
+        right={prettyNumber(vault?.userBalances?.wallet.label)}
+      />
+      <CardItem
+        loading={loading}
+        left={`Shares Pending Withdrawal`}
+        right={prettyNumber(vault?.userBalances?.batchBurn.shares.label ?? 0)}
+      />
+      <CardItem
+        loading={loading}
+        left={"Total Locked Quantity"}
+        right={prettyNumber(locked)}
+      />
+      <CardItem
+        loading={loading}
+        left={`Est. ${vault?.symbol} Withdrawal Value`}
+        right={prettyNumber(pendingUnderlying.label ?? 0)}
+      />
+      <section
+        className="flex justify-between items-center
+          w-full mt-2 sm:my-1 text-gray-600"
+      >
+        <p className="font-bold ml-0 text-sm sm:text-base sm:ml-2">
+          Available to withdraw
+        </p>
+        <WithdrawButton showAvailable />
+      </section>
+    </section>
+  );
+};
 
-const VaultSummaryUser = ({ loading, vault }: {
-    loading: boolean,
-    vault: Vault | undefined
-  }) => {
-    const pendingUnderlying = useApproximatePendingAsUnderlying();
-    return (
-      <section className="
-        flex flex-col w-full justify-evenly h-full items-center">
-        <CardItem
-            loading={loading}
-            left={`Your auxo${vault?.symbol} balance`}
-            right={ prettyNumber(vault?.userBalances?.vault.label) }
-        />
-        <CardItem
-            loading={loading}
-            left={`Est. ${vault?.symbol} value`}
-            right={ prettyNumber(vault?.userBalances?.vaultUnderlying.label) }
-        />        
-        <CardItem
-            loading={loading}
-            left="Fees"
-            right="0 %"
-        />
-        <div className="
-          h-[1px] bg-gray-300 w-full my-5"/>
-        <CardItem
-            loading={loading}
-            left={`Your ${vault?.symbol} Wallet balance`}
-            right={ prettyNumber(vault?.userBalances?.wallet.label) }
-        />
-        <CardItem
-          loading={loading}
-          left={`Shares Pending Withdrawal`}
-          right={ prettyNumber(vault?.userBalances?.batchBurn.shares.label ?? 0) }
-        /> 
-        <CardItem
-          loading={loading}
-          left={`Est. ${vault?.symbol} withdrawal value`}
-          right={ prettyNumber(pendingUnderlying.label ?? 0) }
-        />         
-         <section className="flex justify-between items-center
-          w-full mt-2 sm:my-1 text-gray-600">
-            <p className="font-bold ml-0 text-sm sm:text-base sm:ml-2">Available to withdraw</p>
-            <WithdrawButton showAvailable />
-        </section>
-      </section>     
-    )
-  }
-
-  export default VaultSummaryUser
+export default VaultSummaryUser;

--- a/apps/auxo-app/src/hooks/onChainUtils/fetchOnChainData.ts
+++ b/apps/auxo-app/src/hooks/onChainUtils/fetchOnChainData.ts
@@ -1,0 +1,91 @@
+import { Vault } from "../../store/vault/Vault";
+import {
+  Erc20,
+  MerkleAuth,
+  Mono,
+  Vault as VaultCapped,
+} from "../../types/artifacts/abi";
+import { promiseObject } from "../../utils/promiseObject";
+
+// ** All network calls to smart contracts **
+
+/**
+ * Vault-wide calls that do not need the user signed in.
+ * These will always be available provided we have a network connection
+ */
+const vaultCalls = (mono: Mono, cap: VaultCapped) => ({
+  totalUnderlying: mono.totalUnderlying(),
+  lastHarvest: mono.lastHarvest(),
+  estimatedReturn: mono.estimatedReturn(),
+  batchBurnRound: mono.batchBurnRound(),
+  userDepositLimit: cap.userDepositLimit(),
+  exchangeRate: mono.exchangeRate(),
+});
+
+/**
+ * Account level on-chain information that is only available if the user is connected
+ */
+type AccountCallProps = {
+  account: string | null | undefined;
+  mono: Mono;
+  auth: MerkleAuth;
+  token: Erc20;
+};
+const accountCalls = ({ account, token, auth, mono }: AccountCallProps) => {
+  return (
+    account && {
+      balanceOfUnderlying: token.balanceOf(account),
+      balanceOfVault: mono.balanceOf(account),
+      balanceOfVaultUnderlying: mono.balanceOfUnderlying(account),
+      allowance: token.allowance(account, mono.address),
+      userBatchBurnReceipts: mono.userBatchBurnReceipts(account),
+      isDepositor: auth.isDepositor(mono.address, account),
+    }
+  );
+};
+
+/**
+ * Batch burns rounds need to be fetched from on-chain, so no guarantee we have them during first call.
+ * We also need to inspect the previous batch burn for our purposes, as that provides withdrawal data.
+ */
+const batchBurnCalls = (mono: Mono, batchBurnRound: number | undefined) => {
+  return (
+    batchBurnRound &&
+    batchBurnRound > 0 && {
+      batchBurns: mono.batchBurns(batchBurnRound - 1),
+    }
+  );
+};
+
+/**
+ * Call on chain data by constructing an object of promises, depending on the
+ * Available information we have on hand.
+ */
+type OnChainDataProps = {
+  token: Erc20 | undefined;
+  mono: Mono | undefined;
+  auth: MerkleAuth | undefined;
+  cap: VaultCapped | undefined;
+  vault: Vault;
+  batchBurnRound?: number;
+  account?: string | null;
+};
+export async function fetchOnChainData({
+  token,
+  mono,
+  auth,
+  cap,
+  vault,
+  account,
+  batchBurnRound,
+}: OnChainDataProps) {
+  if (!(mono && token && auth && cap)) return;
+  let onChainCalls = {
+    ...vaultCalls(mono, cap),
+    ...accountCalls({ account, token, mono, auth }),
+    ...batchBurnCalls(mono, batchBurnRound),
+    // pass existing vault data for reference
+    existing: vault,
+  };
+  return await promiseObject(onChainCalls);
+}

--- a/apps/auxo-app/src/hooks/onChainUtils/fetchOnChainData.ts
+++ b/apps/auxo-app/src/hooks/onChainUtils/fetchOnChainData.ts
@@ -87,5 +87,6 @@ export async function fetchOnChainData({
     // pass existing vault data for reference
     existing: vault,
   };
-  return await promiseObject(onChainCalls);
+  const obj = await promiseObject(onChainCalls);
+  return obj;
 }

--- a/apps/auxo-app/src/hooks/onChainUtils/transformOnChainData.ts
+++ b/apps/auxo-app/src/hooks/onChainUtils/transformOnChainData.ts
@@ -1,0 +1,168 @@
+import { Balance, Vault, VaultStats } from "../../store/vault/Vault";
+import { AwaitedReturn, fromScale, toBalance } from "../../utils";
+import { BigNumber } from "@ethersproject/bignumber";
+import { zeroBalance } from "../../utils/balances";
+import { Defined } from "../../types/utilities";
+import { fetchOnChainData } from "./fetchOnChainData";
+
+export type ReturnedChainData = NonNullable<
+  AwaitedReturn<typeof fetchOnChainData>
+>;
+
+/**
+ * Calculate the users' shares available as part of the withdrawal process.
+ *
+ * Amount available depends on the batch burn round:
+ * If the BBR === UserBBR:
+ *   available === 0
+ * Else:
+ *   amount per share * shares
+ */
+const calculateSharesAvailable = ({
+  shares,
+  amountPerShare,
+  decimals,
+  batchBurnRound,
+  userBatchBurnRound,
+}: {
+  shares: BigNumber;
+  amountPerShare: BigNumber;
+  decimals: number;
+  batchBurnRound: number;
+  userBatchBurnRound: number;
+}): Balance => {
+  if (userBatchBurnRound === batchBurnRound) return zeroBalance();
+
+  const scaledPerShare = fromScale(amountPerShare, decimals);
+  const bigAvailable = shares.mul(scaledPerShare);
+  return toBalance(bigAvailable, decimals);
+};
+
+/**
+ * Take the data common to all vaults and convert to a vault stats object
+ */
+const addVaultStatsToVault = (
+  data: ReturnedChainData,
+  decimals: number
+): VaultStats => ({
+  deposits: toBalance(data.totalUnderlying, decimals),
+  lastHarvest: data.lastHarvest.toNumber(),
+  currentAPY: toBalance(data.estimatedReturn, decimals, 2),
+  batchBurnRound: data.batchBurnRound.toNumber(),
+  exchangeRate: toBalance(data.exchangeRate, decimals, 6),
+});
+
+/**
+ * Take the data specific to the account/user and convert to the relevant
+ * Vault state entries
+ */
+const addUserBalanceDataToVault = (
+  accountLevelData: Defined<ReturnedChainData>,
+  currentVault: Vault,
+  decimals: number
+): Vault => {
+  return {
+    ...currentVault,
+
+    auth: {
+      ...currentVault.auth,
+      isDepositor: accountLevelData.isDepositor,
+    },
+
+    userBalances: {
+      wallet: toBalance(accountLevelData.balanceOfUnderlying, decimals),
+      vault: toBalance(accountLevelData.balanceOfVault, decimals),
+      vaultUnderlying: toBalance(
+        accountLevelData.balanceOfVaultUnderlying,
+        decimals
+      ),
+      allowance: toBalance(accountLevelData.allowance as BigNumber, decimals),
+
+      batchBurn: {
+        round: accountLevelData.userBatchBurnReceipts[0].toNumber(),
+        shares: toBalance(accountLevelData.userBatchBurnReceipts[1], decimals),
+        available:
+          currentVault.userBalances?.batchBurn.available ??
+          toBalance(0, decimals),
+      },
+    },
+  };
+};
+
+/**
+ * Take the existing state object and add informating relating to the batchburn and withdraw process
+ * We need this to be separate as it's not guaranteed that we have user and previous batch burn information.
+ */
+const addBatchBurnDataToState = (
+  batchBurnLevelData: Defined<ReturnedChainData>,
+  currentVault: Vault,
+  decimals: number
+) => {
+  return {
+    ...currentVault,
+    userBalances: {
+      ...currentVault.userBalances!,
+      batchBurn: {
+        ...currentVault.userBalances?.batchBurn!,
+        available: calculateSharesAvailable({
+          shares: batchBurnLevelData.userBatchBurnReceipts.shares,
+          amountPerShare: batchBurnLevelData.batchBurns.amountPerShare,
+          decimals,
+          batchBurnRound: batchBurnLevelData.batchBurnRound.toNumber(),
+          userBatchBurnRound:
+            batchBurnLevelData.userBatchBurnReceipts.round.toNumber(),
+        }),
+      },
+    },
+  };
+};
+
+/**
+ * Rebuilds the entire vault as a state object before making a dispatch call.
+ * This allows us to check we actually have changes before triggering
+ * a state update.
+ * Useful for controlling re-renders and preventing hammering of the node.
+ */
+export const toVault = ({
+  existing,
+  data,
+  account,
+}: {
+  existing: Vault;
+  data: AwaitedReturn<typeof fetchOnChainData>;
+  account?: string | null;
+}): Vault | undefined => {
+  if (!data) return;
+  const { decimals } = existing.token;
+
+  let newVault: Vault = {
+    ...existing,
+    stats: {
+      ...addVaultStatsToVault(data, decimals),
+    },
+    cap: {
+      ...existing.cap,
+      underlying: toBalance(data.userDepositLimit, decimals),
+    },
+  };
+
+  // typescript cannot narrow undefined promise responses
+  // even though we know our data is in the call, so we cast the data as defined for these functions
+  if (account) {
+    newVault = addUserBalanceDataToVault(
+      data as Defined<ReturnedChainData>,
+      newVault,
+      decimals
+    );
+  }
+
+  if (data.batchBurns) {
+    newVault = addBatchBurnDataToState(
+      data as Defined<ReturnedChainData>,
+      newVault,
+      decimals
+    );
+  }
+
+  return newVault;
+};

--- a/apps/auxo-app/src/hooks/onChainUtils/transformOnChainData.ts
+++ b/apps/auxo-app/src/hooks/onChainUtils/transformOnChainData.ts
@@ -156,7 +156,7 @@ export const toVault = ({
     );
   }
 
-  if (data.batchBurns) {
+  if (data.batchBurns && account) {
     newVault = addBatchBurnDataToState(
       data as Defined<ReturnedChainData>,
       newVault,

--- a/apps/auxo-app/src/hooks/onChainUtils/transformOnChainData.ts
+++ b/apps/auxo-app/src/hooks/onChainUtils/transformOnChainData.ts
@@ -163,6 +163,5 @@ export const toVault = ({
       decimals
     );
   }
-
   return newVault;
 };

--- a/apps/auxo-app/src/hooks/useBlock.ts
+++ b/apps/auxo-app/src/hooks/useBlock.ts
@@ -5,7 +5,7 @@ import { LibraryProvider, SetStateType } from "../types/utilities";
 import { useWeb3Cache } from "./useCachedWeb3";
 
 // react.strict mode causes double renders which can lead to throttling in dev mode
-const REFRESH_FREQUENCY = process.env.NODE_ENV === "development" ? 20 : 20;
+const REFRESH_FREQUENCY = process.env.NODE_ENV === "development" ? 10 : 10;
 
 type Block = {
   number: number | null | undefined;

--- a/apps/auxo-app/src/hooks/useBlock.ts
+++ b/apps/auxo-app/src/hooks/useBlock.ts
@@ -1,100 +1,78 @@
 import { useWeb3React } from "@web3-react/core";
 import { providers } from "ethers";
-import { useEffect, useState } from "react";
-import { SetStateType } from "../types/utilities";
+import { MutableRefObject, useEffect, useRef, useState } from "react";
+import { LibraryProvider, SetStateType } from "../types/utilities";
 import { useWeb3Cache } from "./useCachedWeb3";
 
 // react.strict mode causes double renders which can lead to throttling in dev mode
-const REFRESH_FREQUENCY = process.env.NODE_ENV === "development" ? 10 : 5;
+const REFRESH_FREQUENCY = process.env.NODE_ENV === "development" ? 20 : 20;
 
 type Block = {
   number: number | null | undefined;
-  lastUpdated: Date | undefined;
 };
 
 type UseBlockReturnType = {
   block: Block;
-  firstLoad: boolean;
   refreshFrequency: number;
 };
 
 const getCurrentBlock = (
   library: providers.Web3Provider | providers.JsonRpcProvider,
-  setBlock: SetStateType<Block>,
-  stale: boolean,
-  setFirst: SetStateType<boolean>
+  setBlock: SetStateType<Block>
 ): void => {
   library
     .getBlockNumber()
     .then((blockNumber: number) => {
-      if (!stale) {
-        // Ensures we can tell components to fetch chain data on first load even with a refesh cadence
-        setFirst(true);
-        setBlock({
-          number: blockNumber,
-          lastUpdated: new Date(),
-        });
-      }
+      setBlock({
+        number: blockNumber,
+      });
     })
     .catch(() => {
       console.warn("Error getting first block");
-      if (!stale) {
-        setBlock({
-          number: null,
-          lastUpdated: new Date(),
-        });
-      }
+      setBlock({
+        number: null,
+      });
     });
 };
 
 const updateBlockNumber = (
   blockNumber: number,
   setBlock: SetStateType<Block>,
-  setFirst: SetStateType<boolean>
+  previousBlockNumber: MutableRefObject<number>
 ): void => {
   if (!blockNumber) return;
   setBlock({
     number: blockNumber,
-    lastUpdated: new Date(),
   });
-  // blocks after first fetch should only trigger RPC calls on interval
-  setFirst(false);
+  previousBlockNumber.current = blockNumber;
 };
 
 export const useBlock = (): UseBlockReturnType => {
-  const { library } =
-    useWeb3React<providers.Web3Provider | providers.JsonRpcProvider>();
-
+  const { library } = useWeb3React<LibraryProvider>();
   const { chainId } = useWeb3Cache();
-  const [first, setFirst] = useState(false);
-  const [block, setBlock] = useState<Block>({
-    number: null,
-    lastUpdated: new Date(),
-  });
+  const [block, setBlock] = useState<Block>({ number: null });
+  const previousBlockNumber = useRef(0);
 
   useEffect(() => {
     if (!library) return;
 
-    let stale = false;
-
     // get the current block to set the initial state
-    getCurrentBlock(library, setBlock, stale, setFirst);
+    getCurrentBlock(library, setBlock);
 
-    // attach the event listener on first mount
-    library.on("block", (blockNumber) =>
-      updateBlockNumber(blockNumber, setBlock, setFirst)
-    );
+    // attach the event listener
+    library.on("block", (blockNumber) => {
+      // Avoid stale blocks by ensuring we only increase block count
+      if (blockNumber > previousBlockNumber.current) {
+        updateBlockNumber(blockNumber, setBlock, previousBlockNumber);
+      }
+    });
 
     // remove the event listener when the component unmounts
     return () => {
-      stale = true;
       library.removeListener("block", updateBlockNumber);
-      setBlock({
-        number: undefined,
-        lastUpdated: new Date(),
-      });
+      setBlock({ number: undefined });
     };
   }, [library, chainId]);
 
-  return { block, firstLoad: first, refreshFrequency: REFRESH_FREQUENCY };
+  return { block, refreshFrequency: REFRESH_FREQUENCY };
 };

--- a/apps/auxo-app/src/hooks/useChainHandler.ts
+++ b/apps/auxo-app/src/hooks/useChainHandler.ts
@@ -14,7 +14,9 @@ export const useChainHandler = (): NetworkDetail | undefined => {
   const dispatch = useAppDispatch();
   const [chain, setChain] = useState<NetworkDetail | undefined>(undefined);
   useEffect(() => {
-    if (chainId && isChainSupported(chainId)) {
+    // Prevent flickering error when the app is loading
+    if (!chainId) return;
+    if (isChainSupported(chainId)) {
       dispatch(clearAlert());
       setChain(chainMap[chainId]);
     } else {

--- a/apps/auxo-app/src/hooks/useContract.ts
+++ b/apps/auxo-app/src/hooks/useContract.ts
@@ -25,7 +25,10 @@ function getMulticallProvider(library: Web3Provider): MulticallProvider {
   /**
    * @dev ensure this is creating a multicall series of requests
    */
-  return new providers.MulticallProvider(library);
+  return new providers.MulticallProvider(library, {
+    // ftm
+    contract: "0x6c31De530342b4F6681B2fE7c420248b920A63A2",
+  });
 }
 
 function getSigner(library: Web3Provider, account: string): JsonRpcSigner {
@@ -54,7 +57,7 @@ export function useContract<T extends Contract>(
   const { library, account, active } = useWeb3React<Web3Provider>();
 
   return useMemo(() => {
-    if (!address || !ABI || !library || !chainId) return undefined;
+    if (!address || !ABI || !library || !chainId) return;
     try {
       if (!active) throw new ProviderNotActivatedError();
       const providerSigner = getProviderOrSigner(library, account);

--- a/apps/auxo-app/src/hooks/useOnChainData.ts
+++ b/apps/auxo-app/src/hooks/useOnChainData.ts
@@ -57,8 +57,9 @@ export const useChainData = (): { loading: boolean } => {
   }, [account, chainId]);
 
   const shouldUpdate = useCallback(() => {
-    // do not update state if vital data missing
-    if (!chainId || !block || !block.number) return false;
+    // do not update state if vital data missing, account null is valid
+    if (!chainId || !block || !block.number || account === undefined)
+      return false;
 
     // Ensure we always fetch data on first load or if key variables change
     if (!lastUpdatedBlock.current) return true;
@@ -96,6 +97,7 @@ export const useChainData = (): { loading: boolean } => {
     capContracts,
     chainId,
     active,
+    account,
   ]);
 
   useEffect(() => {

--- a/apps/auxo-app/src/hooks/useOnChainData.ts
+++ b/apps/auxo-app/src/hooks/useOnChainData.ts
@@ -1,265 +1,68 @@
 import { useWeb3React } from "@web3-react/core";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAppDispatch } from ".";
-import {
-  Erc20,
-  MerkleAuth,
-  Mono,
-  Vault as VaultCapped,
-} from "../types/artifacts/abi";
 import { useContracts } from "./useContract";
-import { Balance, Vault } from "../store/vault/Vault";
-import { AwaitedReturn, fromScale, toBalance } from "../utils";
+import { Vault } from "../store/vault/Vault";
 import { setVaults } from "../store/vault/vault.slice";
-import { BigNumber } from "@ethersproject/bignumber";
 import { chainMap } from "../utils/networks";
 import { useProxySelector } from "../store";
 import hash from "object-hash";
 import { useWeb3Cache } from "./useCachedWeb3";
 import { useBlock } from "./useBlock";
-import { zeroBalance } from "../utils/balances";
-import { promiseObject } from "../utils/promiseObject";
-import { Defined } from "../types/utilities";
-
-/**
- * Vault-wide calls that do not need the user signed in.
- * These will always be available provided we have a network connection
- */
-const vaultCalls = (mono: Mono, cap: VaultCapped) => ({
-  totalUnderlying: mono.totalUnderlying(),
-  lastHarvest: mono.lastHarvest(),
-  estimatedReturn: mono.estimatedReturn(),
-  batchBurnRound: mono.batchBurnRound(),
-  userDepositLimit: cap.userDepositLimit(),
-  exchangeRate: mono.exchangeRate(),
-});
-
-/**
- * Account level on-chain information that is only available if the user is connected
- */
-type AccountCallProps = {
-  account: string | null | undefined;
-  mono: Mono;
-  auth: MerkleAuth;
-  token: Erc20;
-};
-const accountCalls = ({ account, token, auth, mono }: AccountCallProps) => {
-  return (
-    account && {
-      balanceOfUnderlying: token.balanceOf(account),
-      balanceOfVault: mono.balanceOf(account),
-      balanceOfVaultUnderlying: mono.balanceOfUnderlying(account),
-      allowance: token.allowance(account, mono.address),
-      userBatchBurnReceipts: mono.userBatchBurnReceipts(account),
-      isDepositor: auth.isDepositor(mono.address, account),
-    }
-  );
-};
-
-/**
- * Batch burns rounds need to be fetched from on-chain, so no guarantee we have them during first call.
- * We also need to inspect the previous batch burn for our purposes, as that provides withdrawal data.
- */
-const batchBurnCalls = (mono: Mono, batchBurnRound: number | undefined) => {
-  return (
-    batchBurnRound &&
-    batchBurnRound > 0 && {
-      batchBurns: mono.batchBurns(batchBurnRound - 1),
-    }
-  );
-};
-
-/**
- * Call on chain data by constructing an object of promises, depending on the
- * Available information we have on hand.
- */
-type OnChainDataProps = {
-  token: Erc20 | undefined;
-  mono: Mono | undefined;
-  auth: MerkleAuth | undefined;
-  cap: VaultCapped | undefined;
-  batchBurnRound?: number;
-  account?: string | null;
-};
-async function fetchOnChainData({
-  token,
-  mono,
-  auth,
-  cap,
-  account,
-  batchBurnRound,
-}: OnChainDataProps) {
-  if (!(mono && token && auth && cap)) return;
-  let onChainCalls = {
-    ...vaultCalls(mono, cap),
-    ...accountCalls({ account, token, mono, auth }),
-    ...batchBurnCalls(mono, batchBurnRound),
-  };
-  return await promiseObject(onChainCalls);
-}
-
-const calculateAvailable = ({
-  shares,
-  amountPerShare,
-  decimals,
-  batchBurnRound,
-  userBatchBurnRound,
-}: {
-  shares: BigNumber;
-  amountPerShare: BigNumber;
-  decimals: number;
-  batchBurnRound: number;
-  userBatchBurnRound: number;
-}): Balance => {
-  /**
-   * Amount available depends on the batch burn round
-   * If the BBR === UserBBR, available === 0, else it's amount per share * shares
-   */
-  if (userBatchBurnRound === batchBurnRound) {
-    return zeroBalance();
-  }
-  const scaledPerShare = fromScale(amountPerShare, decimals);
-  const bigAvailable = shares.mul(scaledPerShare);
-  return toBalance(bigAvailable, decimals);
-};
-
-/**
- * Add the basic per-vault level data
- */
-const addVaultStats = (
-  data: NonNullable<AwaitedReturn<typeof fetchOnChainData>>,
-  decimals: number
-): Vault["stats"] => ({
-  deposits: toBalance(data.totalUnderlying, decimals),
-  lastHarvest: data.lastHarvest.toNumber(),
-  currentAPY: toBalance(data.estimatedReturn, decimals, 2),
-  batchBurnRound: data.batchBurnRound.toNumber(),
-  exchangeRate: toBalance(data.exchangeRate, decimals, 6),
-});
-
-/**
- * Take the existing state and add user level inforrmation
- */
-const addUserBalanceData = (
-  data: NonNullable<AwaitedReturn<typeof fetchOnChainData>>,
-  currentVault: Vault,
-  decimals: number
-): Vault => {
-  const accountLevelData = data as Defined<typeof data>;
-  return {
-    ...currentVault,
-    auth: {
-      ...currentVault.auth,
-      isDepositor: accountLevelData.isDepositor,
-    },
-    userBalances: {
-      wallet: toBalance(accountLevelData.balanceOfUnderlying, decimals),
-      vault: toBalance(accountLevelData.balanceOfVault, decimals),
-      vaultUnderlying: toBalance(
-        accountLevelData.balanceOfVaultUnderlying,
-        decimals
-      ),
-      allowance: toBalance(data.allowance as BigNumber, decimals),
-      batchBurn: {
-        round: accountLevelData.userBatchBurnReceipts[0].toNumber(),
-        shares: toBalance(accountLevelData.userBatchBurnReceipts[1], decimals),
-        available:
-          currentVault.userBalances?.batchBurn.available ??
-          toBalance(0, decimals),
-      },
-    },
-  };
-};
-
-/**
- * Take the existing state object and add informating relating to the batchburn and withdraw process
- */
-const addBatchBurn = (
-  data: NonNullable<AwaitedReturn<typeof fetchOnChainData>>,
-  currentVault: Vault,
-  decimals: number
-) => {
-  console.debug({ data });
-  const batchBurnLevelData = data as Defined<typeof data>;
-  return {
-    ...currentVault,
-    userBalances: {
-      ...currentVault.userBalances!,
-      batchBurn: {
-        ...currentVault.userBalances?.batchBurn!,
-        available: calculateAvailable({
-          shares: batchBurnLevelData.userBatchBurnReceipts.shares,
-          amountPerShare: batchBurnLevelData.batchBurns.amountPerShare,
-          decimals,
-          batchBurnRound: batchBurnLevelData.batchBurnRound.toNumber(),
-          userBatchBurnRound:
-            batchBurnLevelData.userBatchBurnReceipts.round.toNumber(),
-        }),
-      },
-    },
-  };
-};
-
-const toState = ({
-  existing,
-  decimals,
-  data,
-  account,
-}: {
-  existing: Vault;
-  address: string;
-  decimals: number;
-  data: AwaitedReturn<typeof fetchOnChainData>;
-  account?: string | null;
-}): Vault | undefined => {
-  /**
-   * Rebuilds the entire vault before making a dispatch call
-   * This allows us to check we actually have changes before triggering
-   * a state update. Useful for controlling re-renders and preventing
-   * hammering of the node
-   */
-  if (!data) return;
-
-  let returnValue: Vault = {
-    ...existing,
-    ...addVaultStats(data, decimals),
-    cap: {
-      ...existing.cap,
-      underlying: toBalance(data.userDepositLimit, decimals),
-    },
-  };
-
-  if (account) returnValue = addUserBalanceData(data, returnValue, decimals);
-  if (data.batchBurnRound)
-    returnValue = addBatchBurn(data, returnValue, decimals);
-
-  return returnValue;
-};
+import { fetchOnChainData } from "./onChainUtils/fetchOnChainData";
+import { toVault } from "./onChainUtils/transformOnChainData";
+import { Mono } from "../types/artifacts/abi";
 
 const hasStateChanged = (old: Vault[], change: Vault[]): boolean => {
-  return (
-    hash(old, { encoding: "base64" }) !== hash(change, { encoding: "base64" })
-  );
+  const oldState = hash(old, { encoding: "base64" });
+  const newState = hash(change, { encoding: "base64" });
+  return oldState !== newState;
 };
 
+/**
+ * Fetches onChain calldata through the provider, then compares the result to the
+ * current state to see whether or not to update.
+ *
+ * If a multicall contract is deployed, contract calls will route through the multicall provider.
+ *
+ * A very big caveat with this approach is the RPC rate limits for Metamask:
+ * Excessive calls will return RPC console errors as the node gets throttled and the UI will not be updated.
+ *
+ * Better to invoke calls less frequently, but as needed:
+ * -- Invoke on first load
+ * -- Invoke every X blocks
+ *
+ * -- Don't bother invoking if we are still awaiting the resolution of a previous call
+ *  (this is useful if a large number of blocks come through at once)
+ * -- Don't invoke if we have already processed data for a given blocknumber
+ *  (this is useful because state changes cause a re-render of the hook)
+ */
 export const useChainData = (): { loading: boolean } => {
   const { account, active } = useWeb3React();
+  const [loading, setLoading] = useState(false);
+  const lastUpdatedBlock = useRef<null | number | undefined>(null);
   const { chainId } = useWeb3Cache();
-  const { block, firstLoad, refreshFrequency } = useBlock();
+  const { block, refreshFrequency } = useBlock();
 
   const dispatch = useAppDispatch();
   const vaults = useProxySelector((state) => state.vault.vaults);
   const { monoContracts, tokenContracts, authContracts, capContracts } =
     useContracts(chainId);
 
-  const shouldUpdate = useMemo(() => {
+  const shouldUpdate = useCallback(() => {
     // do not update state if vital data missing
     if (!chainId || !block || !block.number) return false;
 
-    // Ensure we always fetch data when the user loads the page for the first time
-    if (firstLoad) return true;
+    // don't update if state is updating
+    if (loading) return false;
 
-    // repeated state updates can cause rpc throttling with lower block times
+    // Ensure we always fetch data when the user loads the app for the first time
+    if (!lastUpdatedBlock.current) return true;
+
+    // don't update the state if the block number hasn't changed
+    if (block.number === lastUpdatedBlock.current) return false;
+
+    // Refresh data on an interval per X blocks
     const blockFrequencyConditionMet = block.number % refreshFrequency === 0;
 
     // No point updating state if any of the contracts are missing
@@ -276,70 +79,75 @@ export const useChainData = (): { loading: boolean } => {
       blockFrequencyConditionMet
     );
   }, [
-    active,
-    tokenContracts,
-    monoContracts,
-    authContracts,
-    capContracts,
-    firstLoad,
+    loading,
+    lastUpdatedBlock,
     block,
-    chainId,
     refreshFrequency,
+    tokenContracts,
+    authContracts,
+    monoContracts,
+    capContracts,
+    chainId,
+    active,
   ]);
 
   useEffect(() => {
-    if (shouldUpdate) {
+    if (shouldUpdate()) {
+      setLoading(true);
+
       // Multicall contract executes promise all as a batch request
+      // Get all relevant contracts for the underlying token
       Promise.all(
         tokenContracts.map(async (token) => {
           const vault = vaults.find(
             (v) => v.token.address.toLowerCase() === token.address.toLowerCase()
-          );
+          ) as Vault;
           const mono = monoContracts.find(
             (m) => m.address.toLowerCase() === vault?.address.toLowerCase()
-          );
+          ) as Mono;
           const auth = authContracts.find(
             (a) => a.address.toLowerCase() === vault?.auth.address.toLowerCase()
           );
           const cap = capContracts.find(
             (c) => c.address.toLowerCase() === vault?.cap.address.toLowerCase()
           );
-          if (mono && vault) {
-            const data = {
-              vault,
-              address: mono.address,
-              data: await fetchOnChainData({
-                token,
-                mono,
-                auth,
-                cap,
-                batchBurnRound: vault.stats?.batchBurnRound,
-                account,
-              }),
-            };
-            return data;
-          }
+          return await fetchOnChainData({
+            token,
+            mono,
+            auth,
+            cap,
+            batchBurnRound: vault.stats?.batchBurnRound,
+            account,
+            vault,
+          });
         })
       )
-        .then((payload) => {
-          const newVaults = payload.filter(Boolean).map(
-            (p) =>
-              p &&
-              toState({
-                existing: p.vault,
-                address: p.address,
-                decimals: p.vault.token.decimals,
-                data: p.data,
-                account,
-              })
-          ) as Vault[];
+        .then((vaultChainData) => {
+          // convert the vaults to a state object
+          const newVaults = vaultChainData
+            // filter ensures undefined responses are removed and can be safely cast
+            .filter(Boolean)
+            .map(
+              (data) =>
+                data &&
+                toVault({
+                  existing: data.existing,
+                  data,
+                  account,
+                })
+            ) as Vault[];
 
+          // Only trigger a state update if we have new data
           if (newVaults && hasStateChanged(vaults, newVaults)) {
             dispatch(setVaults(newVaults));
           }
         })
         .catch((err) => {
           console.warn("Problem fetching on chain data", err);
+        })
+        .finally(() => {
+          lastUpdatedBlock.current = block.number;
+          setLoading(false);
         });
     }
   }, [
@@ -355,5 +163,5 @@ export const useChainData = (): { loading: boolean } => {
     tokenContracts,
     vaults,
   ]);
-  return { loading: false };
+  return { loading };
 };

--- a/apps/auxo-app/src/store/vault/vault.thunks.ts
+++ b/apps/auxo-app/src/store/vault/vault.thunks.ts
@@ -1,142 +1,126 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { Erc20, MerkleAuth, Mono } from "../../types/artifacts/abi";
-import { LibraryProvider } from "../../types/utilities";
 import { getProof } from "../../utils/merkleProof";
 import { Balance, VaultState } from "./Vault";
 
 /**
- * Thunks allow us to execute asynchronous actions while maintaining a predictable state. 
+ * Thunks allow us to execute asynchronous actions while maintaining a predictable state.
  * In particular, the `createAsyncThunk` method exposes lifecycle methods
  * that can trigger reducers in various parts of the store, depending on the status
  * of a promise.
- * 
+ *
  * Define contract interactions inside the thunk, then return a value that will
  * Be handled by the 'fulfilled' hook, as an extra reducer in the vault slice.
- * 
+ *
  * Rejected values will be passed to the `rejected` handlers.
  * This includes unhandled promise rejections from contract interactions so avoids the necessity
  * for a try/catch block inside the thunk.
- * 
- * If you want notifications to be shown to the user, use the `addTxNotifications` 
- * in the application slice to automatically subscribe to the lifecycle methods 
+ *
+ * If you want notifications to be shown to the user, use the `addTxNotifications`
+ * in the application slice to automatically subscribe to the lifecycle methods
  */
 
-
 /**
- * For ERC20 tokens without a 'permit' method, request an approval from the user for 
+ * For ERC20 tokens without a 'permit' method, request an approval from the user for
  * A transfer of tokens to the auxo vault.
  */
 export type ThunkApproveDepositProps = {
-    deposit: Balance,
-    provider: LibraryProvider,
-    token: Erc20 | undefined,
+  deposit: Balance;
+  token: Erc20 | undefined;
 };
 export const thunkApproveDeposit = createAsyncThunk(
-    'vault/approveDeposit', 
-    async ({
-      deposit, 
-      provider,
-      token
-    }: ThunkApproveDepositProps,
+  "vault/approveDeposit",
+  async (
+    { deposit, token }: ThunkApproveDepositProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!token || !vault.selected) return rejectWithValue('Missing token or selected vault');
+    if (!token || !vault.selected)
+      return rejectWithValue("Missing token or selected vault");
     const tx = await token.approve(vault.selected, deposit.value);
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { deposit }
-        : rejectWithValue('Approval Failed');
-});
-  
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { deposit }
+      : rejectWithValue("Approval Failed");
+  }
+);
+
 /**
  * Actually make the deposit of underlying tokens into the auxo vault
  */
 export type ThunkMakeDepositProps = {
-    deposit: Balance,
-    provider: LibraryProvider,
-    auxo: Mono | undefined,
-    account: string | null | undefined
+  deposit: Balance;
+  auxo: Mono | undefined;
+  account: string | null | undefined;
 };
 export const thunkMakeDeposit = createAsyncThunk(
-    'vault/makeDeposit', 
-    async ({
-      deposit,
-      provider,
-      auxo,
-      account
-    }: ThunkMakeDepositProps,
+  "vault/makeDeposit",
+  async (
+    { deposit, auxo, account }: ThunkMakeDepositProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auxo || !account || !vault.selected) return rejectWithValue(
-        'Missing Contract, Selected Vault or Account Details'
-    );
+    if (!auxo || !account || !vault.selected)
+      return rejectWithValue(
+        "Missing Contract, Selected Vault or Account Details"
+      );
     const tx = await auxo.deposit(account, deposit.value);
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { deposit }
-        : rejectWithValue('Deposit Failed');
-});
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { deposit }
+      : rejectWithValue("Deposit Failed");
+  }
+);
 
 /**
  * Exits the batch burn process, converting all shares currently awaiting a burn into the underlying
  * currency.
  */
 export type ThunkConfirmWithdrawProps = {
-    pendingSharesUnderlying: Balance,
-    provider: LibraryProvider,
-    auxo: Mono | undefined,
+  pendingSharesUnderlying: Balance;
+  auxo: Mono | undefined;
 };
 export const thunkConfirmWithdrawal = createAsyncThunk(
-    'vault/confirmWithdrawal', 
-    async ({
-      pendingSharesUnderlying,
-      provider,
-      auxo,
-    }: ThunkConfirmWithdrawProps,
+  "vault/confirmWithdrawal",
+  async (
+    { pendingSharesUnderlying, auxo }: ThunkConfirmWithdrawProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auxo || !vault.selected) return rejectWithValue(
-        'Missing Contract or Selected Vault'
-    );
-    const tx = await auxo.exitBatchBurn();     
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { pendingSharesUnderlying }
-        : rejectWithValue('Enter Batch Burn Failed');
-});
+    if (!auxo || !vault.selected)
+      return rejectWithValue("Missing Contract or Selected Vault");
+    const tx = await auxo.exitBatchBurn();
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { pendingSharesUnderlying }
+      : rejectWithValue("Enter Batch Burn Failed");
+  }
+);
 
 /**
  * Start the batch burn process by requesting the burning of the users' existing auxo tokens.
  * Users can increase the number of tokens to be converted up and until the batch burn process has completed.
  */
 export type ThunkIncreaseWithdrawalProps = {
-    withdraw: Balance,
-    provider: LibraryProvider,
-    auxo: Mono | undefined,
+  withdraw: Balance;
+  auxo: Mono | undefined;
 };
 export const thunkIncreaseWithdrawal = createAsyncThunk(
-    'vault/increaseWithdrawal', 
-    async ({
-      withdraw,
-      provider,
-      auxo,
-    }: ThunkIncreaseWithdrawalProps,
+  "vault/increaseWithdrawal",
+  async (
+    { withdraw, auxo }: ThunkIncreaseWithdrawalProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auxo || !vault.selected) return rejectWithValue(
-        'Missing Contract or Selected Vault'
-    );
-    const tx = await auxo.enterBatchBurn(withdraw.value);     
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { withdraw }
-        : rejectWithValue('Exit Batch Burn Failed');
-});
-
+    if (!auxo || !vault.selected)
+      return rejectWithValue("Missing Contract or Selected Vault");
+    const tx = await auxo.enterBatchBurn(withdraw.value);
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { withdraw }
+      : rejectWithValue("Exit Batch Burn Failed");
+  }
+);
 
 /**
  * Certain vaults implement a preview mechanism that restricts
@@ -146,27 +130,28 @@ export const thunkIncreaseWithdrawal = createAsyncThunk(
  * There is a merkle root stored on chain which validates the correctness of the proof.
  * Once a user opts in, they are added to the depositors list and can use the vault.
  */
- export type ThunkAuthorizeDepositorProps = {
-    account: string | null | undefined,
-    provider: LibraryProvider,
-    auth: MerkleAuth | undefined,
+export type ThunkAuthorizeDepositorProps = {
+  account: string | null | undefined;
+  auth: MerkleAuth | undefined;
 };
 export const thunkAuthorizeDepositor = createAsyncThunk(
-    'vault/authorizeDepositor', 
-    async ({
-      account,
-      provider,
-      auth,
-    }: ThunkAuthorizeDepositorProps,
+  "vault/authorizeDepositor",
+  async (
+    { account, auth }: ThunkAuthorizeDepositorProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auth || !vault.selected || !account) return rejectWithValue(
-        'Missing Auth Contract, Selected Vault or account details'
-    );
+    if (!auth || !vault.selected || !account)
+      return rejectWithValue(
+        "Missing Auth Contract, Selected Vault or account details"
+      );
     const proof = getProof(account);
-    if (!proof) return rejectWithValue('The current account is unauthorized to use this vault.');
-    const tx = await auth.authorizeDepositor(account, proof);     
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    if (receipt.status !== 1) return rejectWithValue('Authorization Failed');
-});
+    if (!proof)
+      return rejectWithValue(
+        "The current account is unauthorized to use this vault."
+      );
+    const tx = await auth.authorizeDepositor(account, proof);
+    const receipt = await tx.wait();
+    if (receipt.status !== 1) return rejectWithValue("Authorization Failed");
+  }
+);

--- a/apps/auxo-app/src/types/utilities.ts
+++ b/apps/auxo-app/src/types/utilities.ts
@@ -4,3 +4,8 @@ export type SetStateType<T extends any> = (t: T) => void;
 export type LibraryProvider =
   | ethers.providers.Web3Provider
   | ethers.providers.JsonRpcProvider;
+
+// Cast null, optional or undefined properties as definite
+export type Defined<T> = {
+  [P in keyof T]-?: NonNullable<T[P]>;
+};

--- a/apps/auxo-app/src/utils/index.ts
+++ b/apps/auxo-app/src/utils/index.ts
@@ -2,6 +2,7 @@ import { BigNumber } from "@ethersproject/bignumber";
 import { ethers } from "ethers";
 import { Balance } from "../store/vault/Vault";
 
+// Only needed for TS < 4.5
 export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 export type AwaitedReturn<F extends (...args: any) => any> = Awaited<
   ReturnType<F>

--- a/apps/auxo-app/src/utils/logos.tsx
+++ b/apps/auxo-app/src/utils/logos.tsx
@@ -1,4 +1,10 @@
-import { DAIIcon, FRAXIcon, FTMLogo, MIMLogo, USDCIcon } from "../assets/icons/logos";
+import {
+  DAIIcon,
+  FRAXIcon,
+  FTMLogo,
+  MIMLogo,
+  USDCIcon,
+} from "../assets/icons/logos";
 
 const logo = process.env.PUBLIC_URL + "/auxo-icon-green.png";
 


### PR DESCRIPTION
(This PR assumes PRs #20 and #21 will be added to the base branch)

PR addresses two concerns I've had, in readiness for multichain.

## Code quality in the key `useOnChainData` component

1. Refactored the TS file into 3 files: the main hook, the data fetching functions, and the data transformation functions, we store the latter 2 in `/hooks/onChainUtils`.
2. Reduced the size of the data fetching and transformation functions to make them smaller, more easily testable and extensible.
3. Replaced the use of index numbers on the response from Promise.all with strongly typed object values. You now don't have to lookup that `response[9]` is equal to `auxo.balanceOf(account)`, it is instead stored with a proper key and typed value.

## Intermittent connection issues with metamask

 We have a persistent issue with Metamask in the Auxo vaults:

-  Auxo updates the state every X blocks
- Metamask has rate limits on RPC calls before it throttles the user
- Even with state updates every X blocks, we are still seeing RPC errors

I really wanted to get a handle on this so we don't see more errors as we add more vaults and more chains. Added the following fixes:

Prevent unnecessary calls triggered by react re-renders of the main hook, specifically:

1. Ensure block numbers are only increasing, seems to be an issue that previous blocknumbers were coming through and causing extra, unnecessary calls.
2. Ensure we DO trigger a new call if the account or chainId changes.
3. Ensure we don't trigger a call to the network if we already have a network request still resolving
4. Ensure we don't trigger a call to the network if the block number hasn't changed
5. Replace the useMemo with a useCallback as it was causing re-renders through caching the `shouldRender` variable

EDIT: an issue I noticed was that, if the user is connected, the first render shows their account as 'undefined', then 'null'. At this point we do not know if the user is simply not connected, or is waiting for the injected connector to connect.
A solution is to cache the outbound request time (in seconds since unix epoch), and then if multiple requests are sent, we discard any that have an earlier timestamp than our latest.

Also, Added the multicall utils contract address on FTM to the multicall provider options, to ensure it is being used.

 