### PR TITLE
fixed bug with TX null receipts

### DIFF
--- a/apps/auxo-app/src/components/Header/AlertMessage.tsx
+++ b/apps/auxo-app/src/components/Header/AlertMessage.tsx
@@ -53,13 +53,11 @@ function AlertMessage(): JSX.Element {
   const alert = useAppSelector((state) => state.app.alert);
   const dispatch = useAppDispatch();
   useEffect(() => {
-    const timeout = setTimeout(
-      () => {
-        dispatch(setAlertDisplay(false));
-        // nicer to have pending alerts hang around a bit longer
-      },
-      alert.type === "PENDING" ? 6000 : 4000
-    );
+    // pending TX should show for duration
+    if (alert.type === "PENDING") return;
+    const timeout = setTimeout(() => {
+      dispatch(setAlertDisplay(false));
+    }, 4000);
     return () => {
       clearTimeout(timeout);
     };

--- a/apps/auxo-app/src/components/Vault/Actions/Deposit/DepositInput.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/Deposit/DepositInput.tsx
@@ -1,139 +1,156 @@
 import { useState } from "react";
 import { FaCheck } from "react-icons/fa";
 import { useMaxDeposit } from "../../../../hooks/useMaxDeposit";
-import { useApprovalLimit, useSelectedVault, useUserTokenBalance } from "../../../../hooks/useSelectedVault";
+import {
+  useApprovalLimit,
+  useSelectedVault,
+  useUserTokenBalance,
+} from "../../../../hooks/useSelectedVault";
 import { Balance } from "../../../../store/vault/Vault";
 import { compareBalances, zeroBalance } from "../../../../utils/balances";
 import StyledButton from "../../../UI/button";
 import InputSlider from "../InputSlider";
 import { useAppDispatch } from "../../../../hooks";
-import { useMonoVaultContract, useTokenContract } from "../../../../hooks/useContract";
+import {
+  useMonoVaultContract,
+  useTokenContract,
+} from "../../../../hooks/useContract";
 import LoadingSpinner from "../../../UI/loadingSpinner";
 import { useWeb3React } from "@web3-react/core";
 import { prettyNumber } from "../../../../utils";
 import { SetStateType } from "../../../../types/utilities";
 import { logoSwitcher } from "../../../../utils/logos";
-import { thunkApproveDeposit, thunkMakeDeposit } from "../../../../store/vault/vault.thunks";
+import {
+  thunkApproveDeposit,
+  thunkMakeDeposit,
+} from "../../../../store/vault/vault.thunks";
 
 function ApproveDepositButton({ deposit }: { deposit: Balance }) {
-    const [approving, setApproving] = useState(false);
-    const dispatch = useAppDispatch();
-    const vault = useSelectedVault();
-    const { limit } = useApprovalLimit();
-    const tokenContract = useTokenContract(vault?.token.address);
-    const { library } = useWeb3React();
+  const [approving, setApproving] = useState(false);
+  const dispatch = useAppDispatch();
+  const vault = useSelectedVault();
+  const { limit } = useApprovalLimit();
+  const tokenContract = useTokenContract(vault?.token.address);
 
-    const approveDeposit = () => {
-        setApproving(true);
-        dispatch(
-            thunkApproveDeposit({
-                deposit,
-                provider: library,
-                token: tokenContract
-            })
-        ).finally(() => setApproving(false));
-    }
+  const approveDeposit = () => {
+    setApproving(true);
+    dispatch(
+      thunkApproveDeposit({
+        deposit,
+        token: tokenContract,
+      })
+    ).finally(() => setApproving(false));
+  };
 
-    return (
-        <StyledButton
-            disabled={deposit.value === '0' || compareBalances(limit, 'gte', deposit)  || approving}
-            onClick={approveDeposit}
-        >
-            { approving
-                ? <LoadingSpinner />
-                : 'Approve'
-            }
-        </StyledButton>
-    )
+  return (
+    <StyledButton
+      disabled={
+        deposit.value === "0" ||
+        compareBalances(limit, "gte", deposit) ||
+        approving
+      }
+      onClick={approveDeposit}
+    >
+      {approving ? <LoadingSpinner /> : "Approve"}
+    </StyledButton>
+  );
 }
 
-function DepositButtons ({ deposit, setDeposit }: { deposit: Balance, setDeposit: SetStateType<Balance> }) {
-    const [depositing, setDepositing] = useState(false);
-    const dispatch = useAppDispatch();
-    const { account, library, chainId } = useWeb3React();
-    const { limit } = useApprovalLimit();
-    const vault = useSelectedVault();
-    const auxoContract = useMonoVaultContract(vault?.address);
+function DepositButtons({
+  deposit,
+  setDeposit,
+}: {
+  deposit: Balance;
+  setDeposit: SetStateType<Balance>;
+}) {
+  const [depositing, setDepositing] = useState(false);
+  const dispatch = useAppDispatch();
+  const { account, chainId } = useWeb3React();
+  const { limit } = useApprovalLimit();
+  const vault = useSelectedVault();
+  const auxoContract = useMonoVaultContract(vault?.address);
 
-    const buttonDisabled = () => {
-        const invalidDepost = deposit.label <= 0;
-        const sufficientApproval = compareBalances(limit, 'gte', deposit);
-        const wrongNetwork =  chainId !== vault?.network.chainId
-        return !sufficientApproval || wrongNetwork || invalidDepost || depositing; 
-    }   
+  const buttonDisabled = () => {
+    const invalidDepost = deposit.label <= 0;
+    const sufficientApproval = compareBalances(limit, "gte", deposit);
+    const wrongNetwork = chainId !== vault?.network.chainId;
+    return !sufficientApproval || wrongNetwork || invalidDepost || depositing;
+  };
 
-    const makeDeposit = () => { 
-        setDepositing(true);
-        dispatch(
-            thunkMakeDeposit({
-                account, 
-                auxo: auxoContract,
-                deposit,
-                provider: library
-            })
-        )
-        .then(() => setDeposit(zeroBalance()))
-        .finally(() => setDepositing(false));
-    }
-  
-    return (
-        <>
-        <div 
+  const makeDeposit = () => {
+    setDepositing(true);
+    dispatch(
+      thunkMakeDeposit({
+        account,
+        auxo: auxoContract,
+        deposit,
+      })
+    )
+      .then(() => setDeposit(zeroBalance()))
+      .finally(() => setDepositing(false));
+  };
+
+  return (
+    <>
+      <div
         className={`rounded-full p-2 
-            ${
-                !buttonDisabled()
-                ? 'bg-baby-blue-dark'
-                : 'bg-gray-300'
-            }`
-        }>
-        <FaCheck className='fill-white w-4 h-4'/>
-        </div>
-        <StyledButton
-            disabled={buttonDisabled()}
-            onClick={makeDeposit}
-            className={
-                !buttonDisabled()
-                ? 'bg-baby-blue-dark'
-                : 'bg-gray-300'
-            }
-        >
-            Deposit
-        </StyledButton>
-        </>
-    )
+            ${!buttonDisabled() ? "bg-baby-blue-dark" : "bg-gray-300"}`}
+      >
+        <FaCheck className="fill-white w-4 h-4" />
+      </div>
+      <StyledButton
+        disabled={buttonDisabled()}
+        onClick={makeDeposit}
+        className={!buttonDisabled() ? "bg-baby-blue-dark" : "bg-gray-300"}
+      >
+        Deposit
+      </StyledButton>
+    </>
+  );
 }
 
-function DepositActions({ deposit, setDeposit }: { deposit: Balance, setDeposit: SetStateType<Balance> }) {
-    return (
-        <div
-            className="flex justify-between items-center"
-        >
-            <ApproveDepositButton deposit={deposit} />
-            <DepositButtons deposit={deposit} setDeposit={setDeposit} />
-        </div>
-    )
+function DepositActions({
+  deposit,
+  setDeposit,
+}: {
+  deposit: Balance;
+  setDeposit: SetStateType<Balance>;
+}) {
+  return (
+    <div className="flex justify-between items-center">
+      <ApproveDepositButton deposit={deposit} />
+      <DepositButtons deposit={deposit} setDeposit={setDeposit} />
+    </div>
+  );
 }
 
 function DepositInput() {
-    const [deposit, setDeposit] = useState(zeroBalance());
-    const vault = useSelectedVault();
-    const max = useMaxDeposit();
-    const currency = useSelectedVault()?.symbol;
-    const balance = useUserTokenBalance();
-    const label = prettyNumber(balance.label) + ' ' + currency
+  const [deposit, setDeposit] = useState(zeroBalance());
+  const vault = useSelectedVault();
+  const max = useMaxDeposit();
+  const currency = useSelectedVault()?.symbol;
+  const balance = useUserTokenBalance();
+  const label = prettyNumber(balance.label) + " " + currency;
 
-    return (
-        <div className="sm:my-2 flex flex-col h-full w-full justify-evenly px-4">
-            <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
-                <div className="h-6 w-6 sm:h-8 sm:w-8 mr-3">{ logoSwitcher(vault?.symbol) }</div>
-                <p className="text-gray-700 md:text-xl">Deposit {currency}</p>
-            </div>
-            <div className="my-1">
-                <InputSlider value={deposit} setValue={setDeposit} max={max} label={label}/>
-            </div>
-            <DepositActions deposit={deposit} setDeposit={setDeposit}/>
+  return (
+    <div className="sm:my-2 flex flex-col h-full w-full justify-evenly px-4">
+      <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
+        <div className="h-6 w-6 sm:h-8 sm:w-8 mr-3">
+          {logoSwitcher(vault?.symbol)}
         </div>
-    )
+        <p className="text-gray-700 md:text-xl">Deposit {currency}</p>
+      </div>
+      <div className="my-1">
+        <InputSlider
+          value={deposit}
+          setValue={setDeposit}
+          max={max}
+          label={label}
+        />
+      </div>
+      <DepositActions deposit={deposit} setDeposit={setDeposit} />
+    </div>
+  );
 }
 
 export default DepositInput;

--- a/apps/auxo-app/src/components/Vault/Actions/MerkleAuthCheck.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/MerkleAuthCheck.tsx
@@ -2,7 +2,7 @@ import { useWeb3React } from "@web3-react/core";
 import { useState } from "react";
 import { FaCheckCircle } from "react-icons/fa";
 import { useAppDispatch } from "../../../hooks";
-import { useMerkleAuthContract } from "../../../hooks/useContract"
+import { useMerkleAuthContract } from "../../../hooks/useContract";
 import { Vault } from "../../../store/vault/Vault";
 import { thunkAuthorizeDepositor } from "../../../store/vault/vault.thunks";
 import { AUXO_HELP_URL } from "../../../utils";
@@ -11,67 +11,78 @@ import StyledButton from "../../UI/button";
 import LoadingSpinner from "../../UI/loadingSpinner";
 import ExternalUrl from "../../UI/url";
 
-const veDoughLogo = process.env.PUBLIC_URL + '/veDough-only.png'
+const veDoughLogo = process.env.PUBLIC_URL + "/veDough-only.png";
 
 const MerkleVerify = ({ vault }: { vault: Vault }): JSX.Element => {
-  const needsToVerifyString = 'You need to verify before you can use this vault'
-  const verifiedString = 'Account has been verfied';
-  const notAuthorizedString = 'This vault is restricted to veDOUGH holders only';
+  const needsToVerifyString =
+    "You need to verify before you can use this vault";
+  const verifiedString = "Account has been verfied";
+  const notAuthorizedString =
+    "This vault is restricted to veDOUGH holders only";
 
   const dispatch = useAppDispatch();
-  const { account, library, chainId } = useWeb3React();
+  const { account, chainId } = useWeb3React();
   const authContract = useMerkleAuthContract(vault.auth.address);
-  const isDepositor = vault.auth.isDepositor
+  const isDepositor = vault.auth.isDepositor;
   const [authorizing, setAuthorizing] = useState(false);
-  
+
   const proof = getProof(account);
   const isDisabled = (): boolean => {
     const wrongNetwork = chainId !== vault.network.chainId;
     return authorizing || wrongNetwork || !proof;
-  }
-    
+  };
 
   const submitProof = () => {
-    setAuthorizing(true)
+    setAuthorizing(true);
     dispatch(
       thunkAuthorizeDepositor({
-        account, 
+        account,
         auth: authContract,
-        provider: library
       })
     ).finally(() => setAuthorizing(false));
   };
 
   return (
-    <div className="p-5 flex flex-col items-center justify-center">{ 
-      false 
-      ? <LoadingSpinner className="text-gray-600" spinnerClass="text-red"/>
-      :
-      <>
-      { !isDepositor &&
-        <div className="m-auto w-1/2">
-          <img src={veDoughLogo} alt="veDough-holders-only"/>
-        </div>
-      }
-      <p className="my-3 text-lg text-gray-700">{isDepositor ? (proof ? verifiedString : needsToVerifyString) : notAuthorizedString}</p>
-      {
-        isDepositor && <FaCheckCircle size={28} className="fill-baby-blue-dark" />
-      }
-      { 
-        (!isDepositor && proof) && 
-        <StyledButton className="md:w-1/2" 
-          onClick={submitProof}
-          disabled={isDisabled()}>{ authorizing ? <LoadingSpinner /> :'Opt In' }</StyledButton>
-      }
-      { 
-        !isDepositor && 
-        <ExternalUrl to={AUXO_HELP_URL}>
-          <p className="underline text-baby-blue-dark underline-offset-2 text-semibold">More Info</p>
-        </ExternalUrl>
-      }
-      </>
-    }</div>
-  )
-}
+    <div className="p-5 flex flex-col items-center justify-center">
+      {false ? (
+        <LoadingSpinner className="text-gray-600" spinnerClass="text-red" />
+      ) : (
+        <>
+          {!isDepositor && (
+            <div className="m-auto w-1/2">
+              <img src={veDoughLogo} alt="veDough-holders-only" />
+            </div>
+          )}
+          <p className="my-3 text-lg text-gray-700">
+            {isDepositor
+              ? proof
+                ? verifiedString
+                : needsToVerifyString
+              : notAuthorizedString}
+          </p>
+          {isDepositor && (
+            <FaCheckCircle size={28} className="fill-baby-blue-dark" />
+          )}
+          {!isDepositor && proof && (
+            <StyledButton
+              className="md:w-1/2"
+              onClick={submitProof}
+              disabled={isDisabled()}
+            >
+              {authorizing ? <LoadingSpinner /> : "Opt In"}
+            </StyledButton>
+          )}
+          {!isDepositor && (
+            <ExternalUrl to={AUXO_HELP_URL}>
+              <p className="underline text-baby-blue-dark underline-offset-2 text-semibold">
+                More Info
+              </p>
+            </ExternalUrl>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
 
-export default MerkleVerify
+export default MerkleVerify;

--- a/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawButton.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawButton.tsx
@@ -1,4 +1,3 @@
-import { useWeb3React } from "@web3-react/core";
 import { useState } from "react";
 import { useAppDispatch } from "../../../../hooks";
 import { useWeb3Cache } from "../../../../hooks/useCachedWeb3";
@@ -11,50 +10,45 @@ import { prettyNumber } from "../../../../utils";
 import StyledButton from "../../../UI/button";
 import LoadingSpinner from "../../../UI/loadingSpinner";
 
-function WithdrawButton ({ showAvailable }: { showAvailable?: boolean }) {
-    const [withdrawing, setWithdrawing] = useState(false);
-    const { chainId } = useWeb3Cache();
-    const vault = useSelectedVault();
-    const dispatch = useAppDispatch();
-    const { library } = useWeb3React();
-    const auxoContract = useMonoVaultContract(vault?.address);
-    const available = vault?.userBalances?.batchBurn.available;
-    const status = useStatus();
-    const pendingSharesUnderlying = useApproximatePendingAsUnderlying();
+function WithdrawButton({ showAvailable }: { showAvailable?: boolean }) {
+  const [withdrawing, setWithdrawing] = useState(false);
+  const { chainId } = useWeb3Cache();
+  const vault = useSelectedVault();
+  const dispatch = useAppDispatch();
+  const auxoContract = useMonoVaultContract(vault?.address);
+  const available = vault?.userBalances?.batchBurn.available;
+  const status = useStatus();
+  const pendingSharesUnderlying = useApproximatePendingAsUnderlying();
 
-    const buttonText = showAvailable ? prettyNumber(available?.label) : 'WITHDRAW';
-    
-    const buttonDisabled = () => {
-        const wrongStatus = status !== WITHDRAWAL.READY
-        const wrongNetwork =  chainId !== vault?.network.chainId
-        return wrongNetwork || withdrawing || wrongStatus; 
-    }
+  const buttonText = showAvailable
+    ? prettyNumber(available?.label)
+    : "WITHDRAW";
 
-    const makeWithdrawal = () => {
-        setWithdrawing(true);
-        dispatch(
-            thunkConfirmWithdrawal({
-                auxo: auxoContract,
-                provider: library,
-                pendingSharesUnderlying
-            })
-        )
-        .finally(() => setWithdrawing(false))
-    };
+  const buttonDisabled = () => {
+    const wrongStatus = status !== WITHDRAWAL.READY;
+    const wrongNetwork = chainId !== vault?.network.chainId;
+    return wrongNetwork || withdrawing || wrongStatus;
+  };
 
-    return (
-        <StyledButton
-            disabled={buttonDisabled()}
-            onClick={makeWithdrawal}
-            className="min-w-[60px]"
-        >
-            { 
-                withdrawing
-                    ? <LoadingSpinner />
-                    : buttonText
-            } 
-        </StyledButton>
-    )
+  const makeWithdrawal = () => {
+    setWithdrawing(true);
+    dispatch(
+      thunkConfirmWithdrawal({
+        auxo: auxoContract,
+        pendingSharesUnderlying,
+      })
+    ).finally(() => setWithdrawing(false));
+  };
+
+  return (
+    <StyledButton
+      disabled={buttonDisabled()}
+      onClick={makeWithdrawal}
+      className="min-w-[60px]"
+    >
+      {withdrawing ? <LoadingSpinner /> : buttonText}
+    </StyledButton>
+  );
 }
 
-export default WithdrawButton
+export default WithdrawButton;

--- a/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawInput.tsx
+++ b/apps/auxo-app/src/components/Vault/Actions/Withdraw/WithdrawInput.tsx
@@ -1,8 +1,10 @@
-import { useWeb3React } from "@web3-react/core";
 import { useState } from "react";
 import { useAppDispatch } from "../../../../hooks";
 import { useMonoVaultContract } from "../../../../hooks/useContract";
-import { useSelectedVault, useVaultTokenBalance } from "../../../../hooks/useSelectedVault";
+import {
+  useSelectedVault,
+  useVaultTokenBalance,
+} from "../../../../hooks/useSelectedVault";
 import { useStatus, WITHDRAWAL } from "../../../../hooks/useWithdrawalStatus";
 import { Balance } from "../../../../store/vault/Vault";
 import { thunkIncreaseWithdrawal } from "../../../../store/vault/vault.thunks";
@@ -16,94 +18,114 @@ import ExternalUrl from "../../../UI/url";
 import InputSlider from "../InputSlider";
 import WithdrawButton from "./WithdrawButton";
 
-function ApproveWithdrawButton({ withdraw, setWithdraw }: { withdraw: Balance, setWithdraw: SetStateType<Balance> }) {
-    const [approving, setApproving] = useState(false);
-    const dispatch = useAppDispatch();
-    const vault = useSelectedVault();
-    const auxoContract = useMonoVaultContract(vault?.address);
-    const status = useStatus();
-    const { library } = useWeb3React();
+function ApproveWithdrawButton({
+  withdraw,
+  setWithdraw,
+}: {
+  withdraw: Balance;
+  setWithdraw: SetStateType<Balance>;
+}) {
+  const [approving, setApproving] = useState(false);
+  const dispatch = useAppDispatch();
+  const vault = useSelectedVault();
+  const auxoContract = useMonoVaultContract(vault?.address);
+  const status = useStatus();
 
-    const enterBatchBurn = () => {
-        setApproving(true);
-        dispatch(
-            thunkIncreaseWithdrawal({
-                auxo: auxoContract,
-                provider: library,
-                withdraw
-            })
-        ).then(() => setWithdraw(zeroBalance()))
-        .finally(() => setApproving(false));
-    };
-
-    return (
-        <StyledButton
-            disabled={withdraw.value === '0' || status === WITHDRAWAL.READY || approving}
-            onClick={enterBatchBurn}
-        >
-            { approving
-                ? <LoadingSpinner />
-                : 'Request'
-            }
-        </StyledButton>
+  const enterBatchBurn = () => {
+    setApproving(true);
+    dispatch(
+      thunkIncreaseWithdrawal({
+        auxo: auxoContract,
+        withdraw,
+      })
     )
-};
+      .then(() => setWithdraw(zeroBalance()))
+      .finally(() => setApproving(false));
+  };
 
-function WithdrawActions({ withdraw, setWithdraw }: { withdraw: Balance, setWithdraw: SetStateType<Balance> }) {
-    return (
-        <div
-            className="flex w-full justify-start items-center"
-        >
-                <button className="w-full flex justify-start ml-1 text-sm text-gray-500">
-                    <ExternalUrl to={AUXO_HELP_URL + '#c49e2f5991784b7fbb9e7cfac16def3f'}>
-                        <p><span className="underline decoration-baby-blue-dark">More Info</span><span className="hidden sm:inline-block ml-1">on withdrawals</span></p>
-                    </ExternalUrl>
-                </button>
-                <ApproveWithdrawButton withdraw={withdraw} setWithdraw={setWithdraw}/>
-            </div>
-    )
+  return (
+    <StyledButton
+      disabled={
+        withdraw.value === "0" || status === WITHDRAWAL.READY || approving
+      }
+      onClick={enterBatchBurn}
+    >
+      {approving ? <LoadingSpinner /> : "Request"}
+    </StyledButton>
+  );
 }
 
+function WithdrawActions({
+  withdraw,
+  setWithdraw,
+}: {
+  withdraw: Balance;
+  setWithdraw: SetStateType<Balance>;
+}) {
+  return (
+    <div className="flex w-full justify-start items-center">
+      <button className="w-full flex justify-start ml-1 text-sm text-gray-500">
+        <ExternalUrl to={AUXO_HELP_URL + "#c49e2f5991784b7fbb9e7cfac16def3f"}>
+          <p>
+            <span className="underline decoration-baby-blue-dark">
+              More Info
+            </span>
+            <span className="hidden sm:inline-block ml-1">on withdrawals</span>
+          </p>
+        </ExternalUrl>
+      </button>
+      <ApproveWithdrawButton withdraw={withdraw} setWithdraw={setWithdraw} />
+    </div>
+  );
+}
 
 function WithdrawInput() {
-    const [withdraw, setWithdraw] = useState(zeroBalance());
-    const currency = useSelectedVault()?.symbol;
-    const vault = useSelectedVault();
-    const balance = useVaultTokenBalance();
-    const status = useStatus();
-    const label = status === WITHDRAWAL.READY
-        ? 'Ready to Withdraw'
-        : prettyNumber(balance.label) + ' auxo' + currency
-    return (
-        <div 
-            className="
+  const [withdraw, setWithdraw] = useState(zeroBalance());
+  const currency = useSelectedVault()?.symbol;
+  const vault = useSelectedVault();
+  const balance = useVaultTokenBalance();
+  const status = useStatus();
+  const label =
+    status === WITHDRAWAL.READY
+      ? "Ready to Withdraw"
+      : prettyNumber(balance.label) + " auxo" + currency;
+  return (
+    <div
+      className="
             sm:my-2 flex flex-col h-full w-full justify-evenly px-4
-        ">
-            <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
-                <div className="h-6 w-6 sm:h-8 sm:w-8">{ logoSwitcher(vault?.symbol) }</div>
-                <p className="text-gray-700 md:text-xl ml-3 mr-1">Convert auxo{currency} to {currency}</p>
-            </div>
-            {   (status === WITHDRAWAL.READY) ?
-                <div className="h-64 bg-baby-blue-light rounded-xl p-3 text-baby-blue-dark mt-3 flex flex-col items-center justify-evenly">
-                    <p className="text-4xl font-bold underline underline-offset-4 decoration-white">Ready to Withdraw</p>
-                    <p className="">Withdraw your existing balance</p>
-                    <WithdrawButton />
-                </div>
-                : 
-                <>
-                <div className="my-1">
-                    <InputSlider 
-                        value={withdraw}
-                        setValue={setWithdraw}
-                        max={balance}
-                        label={label}
-                    />
-                </div>
-                <WithdrawActions withdraw={withdraw} setWithdraw={setWithdraw} />
-                </>
-            }
+        "
+    >
+      <div className="mb-2 mt-4 flex justify-center sm:justify-start items-center h-10 w-full">
+        <div className="h-6 w-6 sm:h-8 sm:w-8">
+          {logoSwitcher(vault?.symbol)}
         </div>
-    )
+        <p className="text-gray-700 md:text-xl ml-3 mr-1">
+          Convert auxo{currency} to {currency}
+        </p>
+      </div>
+      {status === WITHDRAWAL.READY ? (
+        <div className="h-64 bg-baby-blue-light rounded-xl p-3 text-baby-blue-dark mt-3 flex flex-col items-center justify-evenly">
+          <p className="text-4xl font-bold underline underline-offset-4 decoration-white">
+            Ready to Withdraw
+          </p>
+          <p className="">Withdraw your existing balance</p>
+          <WithdrawButton />
+        </div>
+      ) : (
+        <>
+          <div className="my-1">
+            <InputSlider
+              value={withdraw}
+              setValue={setWithdraw}
+              max={balance}
+              label={label}
+            />
+          </div>
+          <WithdrawActions withdraw={withdraw} setWithdraw={setWithdraw} />
+        </>
+      )}
+    </div>
+  );
 }
 
 export default WithdrawInput;

--- a/apps/auxo-app/src/hooks/useBlock.ts
+++ b/apps/auxo-app/src/hooks/useBlock.ts
@@ -5,7 +5,7 @@ import { LibraryProvider, SetStateType } from "../types/utilities";
 import { useWeb3Cache } from "./useCachedWeb3";
 
 // react.strict mode causes double renders which can lead to throttling in dev mode
-const REFRESH_FREQUENCY = process.env.NODE_ENV === "development" ? 20 : 20;
+const REFRESH_FREQUENCY = process.env.NODE_ENV === "development" ? 10 : 20;
 
 type Block = {
   number: number | null | undefined;

--- a/apps/auxo-app/src/store/vault/vault.thunks.ts
+++ b/apps/auxo-app/src/store/vault/vault.thunks.ts
@@ -1,142 +1,126 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { Erc20, MerkleAuth, Mono } from "../../types/artifacts/abi";
-import { LibraryProvider } from "../../types/utilities";
 import { getProof } from "../../utils/merkleProof";
 import { Balance, VaultState } from "./Vault";
 
 /**
- * Thunks allow us to execute asynchronous actions while maintaining a predictable state. 
+ * Thunks allow us to execute asynchronous actions while maintaining a predictable state.
  * In particular, the `createAsyncThunk` method exposes lifecycle methods
  * that can trigger reducers in various parts of the store, depending on the status
  * of a promise.
- * 
+ *
  * Define contract interactions inside the thunk, then return a value that will
  * Be handled by the 'fulfilled' hook, as an extra reducer in the vault slice.
- * 
+ *
  * Rejected values will be passed to the `rejected` handlers.
  * This includes unhandled promise rejections from contract interactions so avoids the necessity
  * for a try/catch block inside the thunk.
- * 
- * If you want notifications to be shown to the user, use the `addTxNotifications` 
- * in the application slice to automatically subscribe to the lifecycle methods 
+ *
+ * If you want notifications to be shown to the user, use the `addTxNotifications`
+ * in the application slice to automatically subscribe to the lifecycle methods
  */
 
-
 /**
- * For ERC20 tokens without a 'permit' method, request an approval from the user for 
+ * For ERC20 tokens without a 'permit' method, request an approval from the user for
  * A transfer of tokens to the auxo vault.
  */
 export type ThunkApproveDepositProps = {
-    deposit: Balance,
-    provider: LibraryProvider,
-    token: Erc20 | undefined,
+  deposit: Balance;
+  token: Erc20 | undefined;
 };
 export const thunkApproveDeposit = createAsyncThunk(
-    'vault/approveDeposit', 
-    async ({
-      deposit, 
-      provider,
-      token
-    }: ThunkApproveDepositProps,
+  "vault/approveDeposit",
+  async (
+    { deposit, token }: ThunkApproveDepositProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!token || !vault.selected) return rejectWithValue('Missing token or selected vault');
+    if (!token || !vault.selected)
+      return rejectWithValue("Missing token or selected vault");
     const tx = await token.approve(vault.selected, deposit.value);
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { deposit }
-        : rejectWithValue('Approval Failed');
-});
-  
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { deposit }
+      : rejectWithValue("Approval Failed");
+  }
+);
+
 /**
  * Actually make the deposit of underlying tokens into the auxo vault
  */
 export type ThunkMakeDepositProps = {
-    deposit: Balance,
-    provider: LibraryProvider,
-    auxo: Mono | undefined,
-    account: string | null | undefined
+  deposit: Balance;
+  auxo: Mono | undefined;
+  account: string | null | undefined;
 };
 export const thunkMakeDeposit = createAsyncThunk(
-    'vault/makeDeposit', 
-    async ({
-      deposit,
-      provider,
-      auxo,
-      account
-    }: ThunkMakeDepositProps,
+  "vault/makeDeposit",
+  async (
+    { deposit, auxo, account }: ThunkMakeDepositProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auxo || !account || !vault.selected) return rejectWithValue(
-        'Missing Contract, Selected Vault or Account Details'
-    );
+    if (!auxo || !account || !vault.selected)
+      return rejectWithValue(
+        "Missing Contract, Selected Vault or Account Details"
+      );
     const tx = await auxo.deposit(account, deposit.value);
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { deposit }
-        : rejectWithValue('Deposit Failed');
-});
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { deposit }
+      : rejectWithValue("Deposit Failed");
+  }
+);
 
 /**
  * Exits the batch burn process, converting all shares currently awaiting a burn into the underlying
  * currency.
  */
 export type ThunkConfirmWithdrawProps = {
-    pendingSharesUnderlying: Balance,
-    provider: LibraryProvider,
-    auxo: Mono | undefined,
+  pendingSharesUnderlying: Balance;
+  auxo: Mono | undefined;
 };
 export const thunkConfirmWithdrawal = createAsyncThunk(
-    'vault/confirmWithdrawal', 
-    async ({
-      pendingSharesUnderlying,
-      provider,
-      auxo,
-    }: ThunkConfirmWithdrawProps,
+  "vault/confirmWithdrawal",
+  async (
+    { pendingSharesUnderlying, auxo }: ThunkConfirmWithdrawProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auxo || !vault.selected) return rejectWithValue(
-        'Missing Contract or Selected Vault'
-    );
-    const tx = await auxo.exitBatchBurn();     
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { pendingSharesUnderlying }
-        : rejectWithValue('Enter Batch Burn Failed');
-});
+    if (!auxo || !vault.selected)
+      return rejectWithValue("Missing Contract or Selected Vault");
+    const tx = await auxo.exitBatchBurn();
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { pendingSharesUnderlying }
+      : rejectWithValue("Enter Batch Burn Failed");
+  }
+);
 
 /**
  * Start the batch burn process by requesting the burning of the users' existing auxo tokens.
  * Users can increase the number of tokens to be converted up and until the batch burn process has completed.
  */
 export type ThunkIncreaseWithdrawalProps = {
-    withdraw: Balance,
-    provider: LibraryProvider,
-    auxo: Mono | undefined,
+  withdraw: Balance;
+  auxo: Mono | undefined;
 };
 export const thunkIncreaseWithdrawal = createAsyncThunk(
-    'vault/increaseWithdrawal', 
-    async ({
-      withdraw,
-      provider,
-      auxo,
-    }: ThunkIncreaseWithdrawalProps,
+  "vault/increaseWithdrawal",
+  async (
+    { withdraw, auxo }: ThunkIncreaseWithdrawalProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auxo || !vault.selected) return rejectWithValue(
-        'Missing Contract or Selected Vault'
-    );
-    const tx = await auxo.enterBatchBurn(withdraw.value);     
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    return (receipt.status === 1) 
-        ? { withdraw }
-        : rejectWithValue('Exit Batch Burn Failed');
-});
-
+    if (!auxo || !vault.selected)
+      return rejectWithValue("Missing Contract or Selected Vault");
+    const tx = await auxo.enterBatchBurn(withdraw.value);
+    const receipt = await tx.wait();
+    return receipt.status === 1
+      ? { withdraw }
+      : rejectWithValue("Exit Batch Burn Failed");
+  }
+);
 
 /**
  * Certain vaults implement a preview mechanism that restricts
@@ -146,27 +130,28 @@ export const thunkIncreaseWithdrawal = createAsyncThunk(
  * There is a merkle root stored on chain which validates the correctness of the proof.
  * Once a user opts in, they are added to the depositors list and can use the vault.
  */
- export type ThunkAuthorizeDepositorProps = {
-    account: string | null | undefined,
-    provider: LibraryProvider,
-    auth: MerkleAuth | undefined,
+export type ThunkAuthorizeDepositorProps = {
+  account: string | null | undefined;
+  auth: MerkleAuth | undefined;
 };
 export const thunkAuthorizeDepositor = createAsyncThunk(
-    'vault/authorizeDepositor', 
-    async ({
-      account,
-      provider,
-      auth,
-    }: ThunkAuthorizeDepositorProps,
+  "vault/authorizeDepositor",
+  async (
+    { account, auth }: ThunkAuthorizeDepositorProps,
     { getState, rejectWithValue }
-) => {
+  ) => {
     const { vault } = getState() as { vault: VaultState };
-    if (!auth || !vault.selected || !account) return rejectWithValue(
-        'Missing Auth Contract, Selected Vault or account details'
-    );
+    if (!auth || !vault.selected || !account)
+      return rejectWithValue(
+        "Missing Auth Contract, Selected Vault or account details"
+      );
     const proof = getProof(account);
-    if (!proof) return rejectWithValue('The current account is unauthorized to use this vault.');
-    const tx = await auth.authorizeDepositor(account, proof);     
-    const receipt = await provider.getTransactionReceipt(tx.hash);
-    if (receipt.status !== 1) return rejectWithValue('Authorization Failed');
-});
+    if (!proof)
+      return rejectWithValue(
+        "The current account is unauthorized to use this vault."
+      );
+    const tx = await auth.authorizeDepositor(account, proof);
+    const receipt = await tx.wait();
+    if (receipt.status !== 1) return rejectWithValue("Authorization Failed");
+  }
+);


### PR DESCRIPTION
Still calibrating the best way to handle optimistic state updates, but proving hard to do so. 

The approach working locally on ganache fork provides instant TX confirmations.

In a live environment, the receipt returned from the TX is null initially, which throws a TX rejected error, despite the TX being accepted.

PR takes a step back and once again waits for the TX confirmation, but with the much more robust pending TX handling offered by Redux Async Thunks.

