### PR TITLE
Multichain/block footer

### DIFF
--- a/apps/auxo-app/src/hooks/multichain/useMultiChainData.ts
+++ b/apps/auxo-app/src/hooks/multichain/useMultiChainData.ts
@@ -25,7 +25,7 @@ export const hasStateChanged = (old: Vault[], change: Vault[]): boolean => {
 
 // change frequency of updates based on chain to achieve a target state latency
 export const getRefreshFrequency = (chainId: number | undefined): number => {
-  const targetLatency = 60; // seconds
+  const targetLatency = 10; // seconds
   const fallbackFrequency = 10; // blocks
   if (!isChainSupported(chainId)) return fallbackFrequency; // blocks
   const averageBlockTime = chainMap[chainId as SUPPORTED_CHAIN_ID].blockTime; // seconds

--- a/apps/auxo-app/src/hooks/useBlock.ts
+++ b/apps/auxo-app/src/hooks/useBlock.ts
@@ -1,11 +1,12 @@
 import { useWeb3React } from "@web3-react/core";
 import { providers } from "ethers";
-import { MutableRefObject, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { LibraryProvider, SetStateType } from "../types/utilities";
 import { useWeb3Cache } from "./useCachedWeb3";
 
 type Block = {
   number: number | null | undefined;
+  chainId: number | null | undefined;
 };
 
 export type UseBlockReturnType = {
@@ -14,65 +15,57 @@ export type UseBlockReturnType = {
 
 const getCurrentBlock = (
   library: providers.Web3Provider | providers.JsonRpcProvider,
-  setBlock: SetStateType<Block>
+  setBlock: SetStateType<Block>,
+  chainId: number
 ): void => {
   library
     .getBlockNumber()
     .then((blockNumber: number) => {
       setBlock({
         number: blockNumber,
+        chainId,
       });
     })
     .catch(() => {
       console.warn("Error getting first block");
       setBlock({
         number: null,
+        chainId: null,
       });
     });
-};
-
-const updateBlockNumber = (
-  blockNumber: number,
-  setBlock: SetStateType<Block>,
-  previousBlockNumber: MutableRefObject<number>
-): void => {
-  if (!blockNumber) return;
-  setBlock({
-    number: blockNumber,
-  });
-  previousBlockNumber.current = blockNumber;
 };
 
 export const useBlock = (): UseBlockReturnType => {
   const { library } = useWeb3React<LibraryProvider>();
   const { chainId } = useWeb3Cache();
-  const [block, setBlock] = useState<Block>({ number: null });
-  const previousBlockNumber = useRef(0);
+  const [block, setBlock] = useState<Block>({ number: null, chainId: null });
 
   useEffect(() => {
-    // reset previous block fetch if the chain id changes
-    if (chainId) previousBlockNumber.current = 0;
-  }, [chainId]);
+    if (!library || !chainId) return;
 
-  useEffect(() => {
-    if (!library) return;
+    // get the current block to set the initial state
+    getCurrentBlock(library, setBlock, chainId);
 
-    // // get the current block to set the initial state
-    getCurrentBlock(library, setBlock);
+    // Removing event listeners correctly requires
+    // the same named function be bound to the listener as removed
+    // if you don't do this, the listener will not be removed
+    // when we switch networks
+    const updateBlockNumber = (blockNumber: number) => {
+      if (!blockNumber) return;
+      setBlock({
+        number: blockNumber,
+        chainId,
+      });
+    };
 
     // attach the event listener
-    library.on("block", (blockNumber) => {
-      // Avoid stale blocks by ensuring we only increase block count
-      if (blockNumber > previousBlockNumber.current) {
-        updateBlockNumber(blockNumber, setBlock, previousBlockNumber);
-      }
-    });
+    library.on("block", updateBlockNumber);
 
     // remove the event listener when the component unmounts
     return () => {
       library.removeListener("block", updateBlockNumber);
-      setBlock({ number: undefined });
+      setBlock({ number: undefined, chainId: null });
     };
-  }, [library]);
+  }, [library, chainId]);
   return { block };
 };

--- a/apps/auxo-app/src/hooks/useCachedWeb3.ts
+++ b/apps/auxo-app/src/hooks/useCachedWeb3.ts
@@ -23,7 +23,6 @@ export const useSetWeb3Cache = () => {
   const chainId = getChainFromLibrary(library);
   useEffect(() => {
     if (chainId) {
-      console.debug({ chainId });
       dispatch(setChainId(chainId));
     }
   }, [account, active, library, dispatch, chainId]);


### PR DESCRIPTION
Some of my previous problems with block numbers were entirely a result of not unmounting the block listener correctly.

Specifically: removing a listener function requires that the original function:

- Has a reference (named function)
- Is the same function as we added

This fix makes sure we remove a listener properly every time we switch chains. 