### PR TITLE
Separate Pie domain object from entity and add corresponding respository

### DIFF
--- a/apps/backend/src/pies/domain/pie.ts
+++ b/apps/backend/src/pies/domain/pie.ts
@@ -1,0 +1,28 @@
+import BigNumber from 'bignumber.js';
+
+export type Pie = {
+  name: string;
+  symbol: string;
+  address: string;
+  history: PieHistory[];
+  coingeckoId: string;
+};
+
+export type PieHistory = {
+  timestamp: string;
+  nav: number;
+  decimals: number;
+  marginalTVL: BigNumber;
+  totalSupply: BigNumber;
+  underlyingAssets: UnderlyingAsset[];
+};
+
+export type UnderlyingAsset = {
+  address: string;
+  amount: string;
+  usdPrice: string;
+  symbol?: string;
+  decimals?: number;
+  marginalTVL?: BigNumber;
+  marginalTVLPercentage?: number;
+};

--- a/apps/backend/src/pies/entities/pie-history.entity.ts
+++ b/apps/backend/src/pies/entities/pie-history.entity.ts
@@ -1,8 +1,8 @@
-import { ApiProperty } from "@nestjs/swagger";
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { IsObject } from "class-validator";
-import { Document } from 'mongoose';
+import { ApiProperty } from '@nestjs/swagger';
 import { BigNumber } from 'bignumber.js';
+import { Document } from 'mongoose';
+import { UnderlyingAsset } from '../domain/pie';
 
 export type PieHistoryDocument = PieHistoryEntity & Document;
 
@@ -18,7 +18,7 @@ export class PieHistoryEntity {
 
   @Prop()
   @ApiProperty()
-  decimals: number;  
+  decimals: number;
 
   @Prop()
   @ApiProperty()
@@ -26,11 +26,11 @@ export class PieHistoryEntity {
 
   @Prop()
   @ApiProperty()
-  totalSupply: BigNumber;  
+  totalSupply: BigNumber;
 
   @Prop()
   @ApiProperty()
-  underlyingAssets: object[];  
+  underlyingAssets: UnderlyingAsset[];
 }
 
 export const PieHistorySchema = SchemaFactory.createForClass(PieHistoryEntity);

--- a/apps/backend/src/pies/index.ts
+++ b/apps/backend/src/pies/index.ts
@@ -1,0 +1,1 @@
+export * from "./repository";

--- a/apps/backend/src/pies/pies.module.ts
+++ b/apps/backend/src/pies/pies.module.ts
@@ -1,20 +1,35 @@
+import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
-import { HttpModule} from '@nestjs/axios';
 import { MongooseModule } from '@nestjs/mongoose';
-import { PieEntity, PieSchema } from './entities/pie.entity';
 import { CgCoinEntity, CgCoinSchema } from './entities/cg_coin.entity';
-import { PieHistoryEntity, PieHistorySchema } from './entities/pie-history.entity';
+import {
+  PieHistoryEntity,
+  PieHistorySchema,
+} from './entities/pie-history.entity';
+import { PieEntity, PieSchema } from './entities/pie.entity';
 import { PiesController } from './pies.controller';
 import { PiesService } from './pies.service';
+import { MongoPieRepository } from './repository/MongoPieRepository';
+import { PieRepository } from './repository/PieRepository';
+
+export const MongoPieRepositoryProvider = {
+  provide: PieRepository,
+  useClass: MongoPieRepository,
+};
 
 @Module({
   imports: [
     HttpModule,
     MongooseModule.forFeature([{ name: PieEntity.name, schema: PieSchema }]),
-    MongooseModule.forFeature([{ name: PieHistoryEntity.name, schema: PieHistorySchema }]),
-    MongooseModule.forFeature([{ name: CgCoinEntity.name, schema: CgCoinSchema }])
+    MongooseModule.forFeature([
+      { name: PieHistoryEntity.name, schema: PieHistorySchema },
+    ]),
+    MongooseModule.forFeature([
+      { name: CgCoinEntity.name, schema: CgCoinSchema },
+    ]),
   ],
   controllers: [PiesController],
-  providers: [PiesService]
+  providers: [PiesService, MongoPieRepositoryProvider],
+  exports: [MongoPieRepositoryProvider],
 })
 export class PiesModule {}

--- a/apps/backend/src/pies/repository/MongoPieRepository.spec.ts
+++ b/apps/backend/src/pies/repository/MongoPieRepository.spec.ts
@@ -1,0 +1,98 @@
+import { MongooseModule } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import BigNumber from 'bignumber.js';
+import { v4 as uuid } from 'uuid';
+import {
+  PieHistoryEntity,
+  PieHistorySchema,
+} from '../entities/pie-history.entity';
+import { PieEntity, PieSchema } from '../entities/pie.entity';
+import { MongoPieRepository } from './MongoPieRepository';
+
+describe('Given a PieRepository', () => {
+  let target: MongoPieRepository;
+  let app: TestingModule;
+
+  beforeEach(async () => {
+    app = await Test.createTestingModule({
+      controllers: [],
+      providers: [MongoPieRepository],
+      imports: [
+        MongooseModule.forRoot(process.env.MONGO_DB_TEST),
+        MongooseModule.forFeature([
+          { name: PieEntity.name, schema: PieSchema },
+        ]),
+        MongooseModule.forFeature([
+          { name: PieHistoryEntity.name, schema: PieHistorySchema },
+        ]),
+      ],
+    }).compile();
+
+    target = app.get<MongoPieRepository>(MongoPieRepository);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('When trying to create a new Pie without history', () => {
+    it('Then it is successfully created', async () => {
+      const name = uuid();
+
+      const pie = {
+        name: name,
+        address: '0x0',
+        coingeckoId: '0',
+        history: [],
+        symbol: 'TST',
+      };
+
+      await target.create(pie);
+
+      const result = await target.findOneByName(name);
+
+      expect(result).toEqual(pie);
+    });
+  });
+
+  describe('When trying to create a new Pie with history', () => {
+    it('Then it is successfully created', async () => {
+      const name = uuid();
+
+      const pie = {
+        name: name,
+        address: '0x0',
+        coingeckoId: '0',
+        history: [
+          {
+            timestamp: '1648158300006',
+            nav: 0.9989370855600695,
+            decimals: 18,
+            marginalTVL: new BigNumber('42776.27367578742775509122'),
+            totalSupply: new BigNumber('0x09115fb5923bc049e09e'),
+            underlyingAssets: [
+              {
+                address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                symbol: 'USDC',
+                decimals: 6,
+                amount: '20151719756',
+                usdPrice: '0.998853',
+                marginalTVL: new BigNumber('20128.605733439868'),
+                marginalTVLPercentage: 47.05553804429024902233,
+              },
+            ],
+          },
+        ],
+        symbol: 'TST',
+      };
+
+      await target.create(pie);
+
+      const result = await target.findOneByName(name);
+
+      expect(jsonify(result)).toEqual(jsonify(pie));
+    });
+  });
+});
+
+const jsonify = <T>(obj: T) => JSON.parse(JSON.stringify(obj));

--- a/apps/backend/src/pies/repository/MongoPieRepository.ts
+++ b/apps/backend/src/pies/repository/MongoPieRepository.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Pie, PieHistory } from '../domain/pie';
+import {
+  PieHistoryDocument,
+  PieHistoryEntity,
+} from '../entities/pie-history.entity';
+import { PieDocument, PieEntity } from '../entities/pie.entity';
+import { PieRepository } from './PieRepository';
+
+@Injectable()
+export class MongoPieRepository extends PieRepository {
+  constructor(
+    @InjectModel(PieEntity.name) private pieModel: Model<PieDocument>,
+    @InjectModel(PieHistoryEntity.name)
+    private pieHistoryModel: Model<PieHistoryDocument>,
+  ) {
+    super();
+  }
+
+  async create(pie: Pie): Promise<Pie> {
+    const pieEntity = new this.pieModel({
+      name: pie.name,
+      symbol: pie.symbol,
+      address: pie.address,
+      history: [],
+      coingecko_id: pie.coingeckoId,
+    });
+
+    for (const history of pie.history) {
+      const historyEntity = new this.pieHistoryModel({
+        timestamp: history.timestamp,
+        nav: history.nav,
+        decimals: history.decimals,
+        marginalTVL: history.marginalTVL,
+        totalSupply: history.totalSupply,
+        underlyingAssets: history.underlyingAssets,
+      });
+      pieEntity.history.push(await historyEntity.save());
+    }
+
+    await pieEntity.save();
+
+    return pie;
+  }
+
+  async findOneByName(name: string): Promise<Pie | null> {
+    const result = await this.pieModel
+      .findOne({ name })
+      .populate('history')
+      .exec();
+    return result ? entityToPie([result])[0] : null;
+  }
+
+  async findOneBySymbol(symbol: string): Promise<Pie | null> {
+    const result = await this.pieModel
+      .findOne({ symbol })
+      .populate('history')
+      .exec();
+    return result ? entityToPie([result])[0] : null;
+  }
+
+  async findAll(): Promise<Pie[]> {
+    return this.pieModel.find().populate('history').map(entityToPie);
+  }
+}
+
+const entityToPie = (docs: PieDocument[]): Pie[] => {
+  return docs.map((doc) => {
+    return {
+      name: doc.name,
+      symbol: doc.symbol,
+      address: doc.address,
+      history: entityToHistory(doc.history),
+      coingeckoId: doc.coingecko_id,
+    };
+  });
+};
+
+const entityToHistory = (docs: PieHistoryEntity[]): PieHistory[] => {
+  return docs.map((doc) => {
+    return {
+      timestamp: doc.timestamp,
+      nav: doc.nav,
+      decimals: doc.decimals,
+      marginalTVL: doc.marginalTVL,
+      totalSupply: doc.totalSupply,
+      underlyingAssets: doc.underlyingAssets.map((x) => x),
+    };
+  });
+};

--- a/apps/backend/src/pies/repository/PieRepository.ts
+++ b/apps/backend/src/pies/repository/PieRepository.ts
@@ -1,0 +1,33 @@
+import { Pie } from '../domain/pie';
+
+export abstract class PieRepository {
+  abstract create(pie: Pie): Promise<Pie>;
+  abstract findOneByName(name: string): Promise<Pie | null>;
+  abstract findOneBySymbol(symbol: string): Promise<Pie | null>;
+  abstract findAll(): Promise<Pie[]>;
+}
+
+export class PieRepositoryStub extends PieRepository {
+  constructor(private pies: Pie[]) {
+    super();
+  }
+
+  create(pie: Pie): Promise<Pie> {
+    this.pies.push(pie);
+    return Promise.resolve(pie);
+  }
+
+  findOneByName(name: string): Promise<Pie> {
+    const result = this.pies.find((p) => p.name === name);
+    return result ? Promise.resolve(result) : Promise.resolve(null);
+  }
+
+  findOneBySymbol(symbol: string): Promise<Pie> {
+    const result = this.pies.find((p) => p.symbol === symbol);
+    return result ? Promise.resolve(result) : Promise.resolve(null);
+  }
+
+  findAll(): Promise<Pie[]> {
+    return Promise.resolve(this.pies);
+  }
+}

--- a/apps/backend/src/pies/repository/index.ts
+++ b/apps/backend/src/pies/repository/index.ts
@@ -1,0 +1,2 @@
+export * from "./MongoPieRepository";
+export * from "./PieRepository";


### PR DESCRIPTION
In this PR I've created a new domain object (`Pie`) to separate the domain model from the underlying database entity. I've also created the corresponding `Repository` implementation that encapsulates database access.