### PR TITLE
Sdk/multicall

### DIFF
--- a/libs/sdk-utils/multicall/src/examples/index.ts
+++ b/libs/sdk-utils/multicall/src/examples/index.ts
@@ -1,0 +1,59 @@
+import { BigNumber, ethers } from 'ethers';
+import { Erc20Abi as ERC20 } from '@shared/util-blockchain';
+import { erc20 } from '@shared/util-blockchain/abis';
+import { MultiCallWrapper } from '../lib/sdk-utils-multicall';
+import { promiseObject } from '@shared/helpers';
+
+// 🐋🐋🐋🐋🐋🐋🐋🐋🐋
+const USDCholders = [
+  '0x95bf7e307bc1ab0ba38ae10fc27084bc36fcd605',
+  '0x12edea9cd262006cc3c4e77c90d2cd2dd4b1eb97',
+  '0xe61dd9ca7364225afbfb79e15ad33864424e6ae4',
+  '0x2b4c76d0dc16be1c31d4c1dc53bf9b45987fc75c',
+  '0x083dee8e5ca1e100a9c9ec0744f461b3507e9376',
+  '0xcb54ea94191b280c296e6ff0e37c7e76ad42dc6a',
+];
+
+// Use a provider other than default (i.e. with FTM)
+export async function main() {
+  const ftmProvider = new ethers.providers.JsonRpcProvider(
+    'https://rpc.ftm.tools​',
+  );
+  const multicall = new MultiCallWrapper(ftmProvider);
+
+  const usdc = {
+    address: '0x04068da6c83afcfa0e13ba15a6696662335d5b75',
+    abi: erc20,
+  };
+
+  const usdcContract = multicall.create<ERC20>(usdc.address, usdc.abi);
+
+  // aggregate calls
+  const calls = USDCholders.reduce(
+    (obj, holder) => ({
+      ...obj,
+      [holder]: usdcContract.balanceOf(holder),
+    }),
+    {} as Record<string, Promise<BigNumber>>,
+  );
+
+  const dec = { decimals: usdcContract.decimals() };
+  const newCalls = { ...calls, ...dec } as typeof calls & typeof dec;
+
+  // fire through a promise all call
+  // this will trigger the multicall to batch calls
+  const results = await promiseObject(newCalls);
+
+  // paste results
+  Object.entries(results).forEach(([holder, quantity]) => {
+    if (typeof quantity !== 'number') {
+      console.log(
+        'holder:',
+        holder,
+        'quantity',
+        // human readable
+        quantity.div(BigNumber.from(10).pow(results.decimals)).toNumber(),
+      );
+    }
+  });
+}

--- a/libs/sdk-utils/multicall/src/lib/sdk-utils-multicall.spec.ts
+++ b/libs/sdk-utils/multicall/src/lib/sdk-utils-multicall.spec.ts
@@ -1,7 +1,53 @@
-import { sdkUtilsMulticall } from './sdk-utils-multicall';
+import { typesafeContract } from '@sdk-utils/core';
+import { Erc20Abi as Erc20 } from '@shared/util-blockchain';
+import { erc20 as erc20Abi } from '@shared/util-blockchain/abis';
+import { ethers } from 'ethers';
+import { MultiCallWrapper } from './sdk-utils-multicall';
 
-describe('sdkUtilsMulticall', () => {
-  it('should work', () => {
-    expect(sdkUtilsMulticall()).toEqual('sdk-utils-multicall');
+describe('Multicall Wrapper testing', () => {
+  const multicall = new MultiCallWrapper();
+  const address = '0xad32A8e6220741182940c5aBF610bDE99E737b2D'; // DOUGH
+  const contract = typesafeContract<Erc20>(address, erc20Abi);
+  const multicallDough = multicall.wrap(contract);
+
+  describe('Testing the multicall instantiation', () => {
+    it('Should wrap an existing contract', () => {
+      expect(multicallDough.isMulticallEnabled).toEqual(true);
+    });
+
+    it('Should be able to call the same methods', async () => {
+      const decimals = await multicallDough.decimals();
+      expect(decimals).toEqual(18);
+    });
+
+    it('Should create a new instance of a multicall enabled contract, when passed params', () => {
+      const newMulticallDough = multicall.create<Erc20>(address, erc20Abi);
+      expect(newMulticallDough.isMulticallEnabled).toEqual(true);
+    });
+  });
+
+  describe('Making multicalls through the multicall contract', () => {
+    it('Batches multiple calls as one call through the multicall contract', async () => {
+      // access private variables in TS through string notation
+      const spy = jest.spyOn(multicallDough.provider['multicall'], 'run');
+
+      await Promise.all([
+        multicallDough.decimals(),
+        multicallDough.balanceOf(ethers.constants.AddressZero),
+      ]);
+
+      expect(spy).toBeCalledTimes(1);
+    });
+
+    it('Runs individual await calls as separate calls', async () => {
+      const spy = jest.spyOn(multicallDough.provider['multicall'], 'run');
+
+      await multicallDough.decimals();
+      await multicallDough.decimals();
+
+      // add the first call for a total of 3
+      // resetting mocks causes timeout error, not ideal but easier than debugging jest internals
+      expect(spy).toBeCalledTimes(3);
+    });
   });
 });

--- a/libs/sdk-utils/multicall/src/lib/sdk-utils-multicall.ts
+++ b/libs/sdk-utils/multicall/src/lib/sdk-utils-multicall.ts
@@ -1,23 +1,48 @@
-export function sdkUtilsMulticall(): string {
-  return 'sdk-utils-multicall';
-}
-
-
-/**
- * MyType extends a `thing` that does some `stuff`
- */
-interface MyType {
-  // the value of choice
-  myValue: string
-}
-
+import { ContractWrapper, decorate } from '@sdk-utils/core';
+import { providers as _0xS } from '@0xsequence/multicall';
+import { Contract, ethers } from 'ethers';
+import { Provider } from '@ethersproject/providers';
 
 /**
- * do stuff is a great function
+ * Multicall implementation with 0xSequence happens automatically.
+ * There are no special methods to call, but we add this flag purely as an indicator to show the contract has been wrapped.
  */
-export async function doStuff(input: unknown): Promise<MyType> {
+type Multicall = {
+  isMulticallEnabled: boolean;
+};
 
-  return {
-    myValue: String(input),
+/**
+ * A list of contract addresses for multicall, on different networks.
+ *
+ * Visit [The 0xSequence Multicall page](https://github.com/0xsequence/sequence.js/tree/master/packages/multicall) for details.
+ */
+export const MULTICALLCONTRACTS = {
+  // Put deployed contracts here
+  1: '0xd130B43062D875a4B7aF3f8fc036Bc6e9D3E1B3E',
+};
+
+export class MultiCallWrapper extends ContractWrapper<Multicall> {
+  private multicallProvider?: _0xS.MulticallProvider;
+  public contracts: Contract[] = [];
+
+  constructor(provider?: Provider) {
+    super();
+    this.setMulticallProvider(provider);
+  }
+
+  private setMulticallProvider(provider: undefined | Provider) {
+    const actualProvider = this.getProvider(provider);
+    this.multicallProvider = new _0xS.MulticallProvider(actualProvider);
+  }
+
+  private getProvider(provider: undefined | Provider): Provider {
+    return provider ?? ethers.providers.getDefaultProvider();
+  }
+
+  public wrap<C extends Contract>(contract: C): C & Multicall {
+    const multicallEnabledContract = contract.connect(
+      this.multicallProvider!,
+    ) as C;
+    return decorate(multicallEnabledContract, { isMulticallEnabled: true });
   }
 }

--- a/libs/shared/util-blockchain/abis/erc20/erc20.abi.json
+++ b/libs/shared/util-blockchain/abis/erc20/erc20.abi.json
@@ -1,0 +1,222 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/libs/shared/util-blockchain/abis/index.ts
+++ b/libs/shared/util-blockchain/abis/index.ts
@@ -1,0 +1,6 @@
+import erc20 from './erc20/erc20.abi.json';
+import pievault from './pie-vault/pievault.abi.json';
+import smartPool from './smart-pool/smartpool.abi.json';
+import yieldVault from './yield-vault/yieldvault.abi.json';
+
+export { erc20, pievault, smartPool, yieldVault };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,7 +26,8 @@
       ],
       "@shared/helpers": ["libs/shared/helpers/src/index.ts"],
       "@shared/ui-library": ["libs/shared/ui-library/src/index.ts"],
-      "@shared/util-blockchain": ["libs/shared/util-blockchain/src/index.ts"]
+      "@shared/util-blockchain": ["libs/shared/util-blockchain/src/index.ts"],
+      "@shared/util-blockchain/abis": ["libs/shared/util-blockchain/abis"]
     },
     "types": ["jest", "node"]
   },


### PR DESCRIPTION
Building on the work of #61 , this PR adds multicall support into the SDK by implementing the 0xSequence library. This allows for automatic multicall aggregation of multiple calls when encased in `Promise.all`.

Considering adding a static method to the class to use the `promiseObject` util for cleaner aggregation of multiple calls, but it's not required yet.