### PR TITLE
Hide Migration Section and Implement Home Redirect

### DIFF
--- a/apps/auxo/components/NavBar/NavBar.tsx
+++ b/apps/auxo/components/NavBar/NavBar.tsx
@@ -167,7 +167,7 @@ export function NavBar() {
 export const GoToApp = () => {
   const { t } = useTranslation();
   return (
-    <Link passHref href="/migration">
+    <Link passHref href="/ARV">
       <button className="w-fit px-4 py-1 text-base text-white bg-secondary rounded-full ring-inset ring-1 ring-secondary enabled:hover:bg-transparent enabled:hover:text-secondary disabled:cursor-not-allowed disabled:opacity-70 flex gap-x-2 items-center font-medium">
         <TemplateIcon className="fill-current w-4 h-4" />
         {t('launchApp')}

--- a/apps/auxo/components/Navigation/Navigation.tsx
+++ b/apps/auxo/components/Navigation/Navigation.tsx
@@ -40,11 +40,6 @@ export default function Navigation({
     { name: t('ARV'), href: '/ARV', icon: <ArvIcon className="w-6 h-6" /> },
     { name: t('PRV'), href: '/PRV', icon: <PrvIcon className="w-6 h-6" /> },
     { name: t('rewards'), href: '/rewards', icon: <BanknotesIcon /> },
-    {
-      name: t('migration'),
-      href: '/migration',
-      icon: <TrendingUpIcon className="w-6 h-6" />,
-    },
   ];
 
   useEffect(() => {

--- a/apps/auxo/next.config.js
+++ b/apps/auxo/next.config.js
@@ -29,8 +29,18 @@ const nextConfig = {
     return [
       {
         source: '/vaults/:slug',
-        destination: '/migration',
+        destination: '/',
         permanent: false,
+      },
+      {
+        source: '/migration/:slug*',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/migration',
+        destination: '/',
+        permanent: true,
       },
     ];
   },


### PR DESCRIPTION
This pull request addresses the need to hide the Migration section of the website and redirect users to the homepage instead.

- Removed links to the Migration section from the navigation menu and other relevant areas of the website (Launch App on Home)
- Implemented a URL redirect from all Migration pages to the Homepage.